### PR TITLE
ci: add npm log archiving for Github Actions

### DIFF
--- a/.github/workflows/higgs-shop-sample-app-pull-request.yml
+++ b/.github/workflows/higgs-shop-sample-app-pull-request.yml
@@ -37,3 +37,10 @@ jobs:
 
             - name: Run tests
               run: npm run test
+
+            - name: Archive npm failure logs
+              uses: actions/upload-artifact@v2
+              if: failure()
+              with:
+                name: npm-logs
+                path: ~/.npm/_logs

--- a/.github/workflows/higgs-shop-sample-app-release.yml
+++ b/.github/workflows/higgs-shop-sample-app-release.yml
@@ -89,3 +89,10 @@ jobs:
                 -p @semantic-release/git@9 \
                 -p @semantic-release/exec@5 \
                 semantic-release
+
+            - name: Archive npm failure logs
+              uses: actions/upload-artifact@v2
+              if: failure()
+              with:
+                name: npm-logs
+                path: ~/.npm/_logs


### PR DESCRIPTION
# Summary

Set up npm log archiving for easier troubleshooting of any node errors.
