### PR TITLE
feat: Update Dependabot Merge Process

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,10 +6,6 @@ updates:
         interval: daily
         time: "08:00"
         timezone: "America/New_York"
-      target-branch: 'development'
+      target-branch: 'chore/development'
       labels: ['dependabot']
       open-pull-requests-limit: 10
-      ignore:
-          - dependency-name: 'rollup'
-          - dependency-name: 'browserify'
-          - dependency-name: '@babel/runtime'

--- a/.github/workflows/dependabot-branch-rebase.yml
+++ b/.github/workflows/dependabot-branch-rebase.yml
@@ -1,0 +1,12 @@
+name: "Dependabot Branch Rebase"
+
+on:
+    push:
+      branches:
+        - development
+    workflow_dispatch:
+
+jobs:
+  rebase-branch:
+    name: "Rebase Development onto Dependabot Branch"
+    uses: mParticle/mparticle-workflows/.github/workflows/dependabot-rebase-development.yml@stable

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,0 +1,39 @@
+name: "Pull Request Checks"
+
+on: [ pull_request_target ]
+
+jobs:
+
+  higgs-shop-sample-app:
+    name: "Check Higgs Shop Sample App PR"
+    uses: ./.github/workflows/higgs-shop-sample-app-pull-request.yml
+    with:
+      app_relative_path: "core-sdk-samples/higgs-shop-sample-app"
+
+  automerge-dependabot:
+    name: "Automerge Dependabot PR"
+    needs: [ higgs-shop-sample-app ]
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    env:
+      GITHUB_TOKEN: ${{ secrets.MP_SEMANTIC_RELEASE_BOT }}
+      GIT_AUTHOR_NAME: mparticle-bot
+      GIT_AUTHOR_EMAIL: developers@mparticle.com
+      GIT_COMMITTER_NAME: mparticle-bot
+      GIT_COMMITTER_EMAIL: developers@mparticle.com
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Rebase Dependabot PR"
+        uses: actions/github-script@v3
+        with:
+          script: |
+            github.pulls.merge({
+                owner: context.repo.owner,
+                repo: context.payload.repository.name,
+                pull_number: context.payload.pull_request.number,
+                merge_method: 'rebase'
+            });
+  rebase-development:
+      name: "Rebase Development onto Dependabot Branch"
+      needs: [ automerge-dependabot ]
+      if: ${{ github.actor == 'dependabot[bot]' }}
+      uses: mParticle/mparticle-workflows/.github/workflows/dependabot-rebase-development.yml@stable


### PR DESCRIPTION
## Summary

We tend to get quite a few dependabot updates and individually merging them has become unnecessarily complex. To make this more manageable, our new approach will be to combine multiple dependabot merges into a single release branch and configure them to auto merge on a daily basis.

Tests will still be run on these pull requests, so that if they do not pass tests, they will not merge. This will allow us to flag breaking changes while automating keeping our project up-to-date

## Master Issue
- Closes https://go.mparticle.com/work/SQDSDKS-3651
