### PR TITLE
ci: update semantic release to patch additional prefixes

### DIFF
--- a/core-sdk-samples/higgs-shop-sample-app/release.config.js
+++ b/core-sdk-samples/higgs-shop-sample-app/release.config.js
@@ -8,6 +8,18 @@ module.exports = {
             '@semantic-release/commit-analyzer',
             {
                 preset: 'angular',
+                releaseRules: [
+                    { type: 'feat', release: 'minor' },
+                    { type: 'ci', release: 'patch' },
+                    { type: 'fix', release: 'patch' },
+                    { type: 'docs', release: 'patch' },
+                    { type: 'test', release: 'patch' },
+                    { type: 'refactor', release: 'patch' },
+                    { type: 'style', release: 'patch' },
+                    { type: 'build', release: 'patch' },
+                    { type: 'chore', release: 'patch' },
+                    { type: 'revert', release: 'patch' },
+                ],
             },
         ],
         [


### PR DESCRIPTION
## Summary
Previously, only prefixes `fix, `feat`, and `major` impact the version number upon a semantic release. We should have other prefixes also increment the patch version similar to `fix`.

Pulled from [Android SDK](https://github.com/mParticle/mparticle-android-sdk/blob/main/release.config.js#L9-L20)

## Testing Plan
Ci update only

## Master Issue
Closes https://go.mparticle.com/work/SQDSDKS-3941