### PR TITLE
feat: Allow API Key to be set via UI and persist when hosted

### DIFF
--- a/core-sdk-samples/higgs-shop-sample-app/src/components/APIKeyHeaderBar/APIKeyHeaderBar.test.tsx
+++ b/core-sdk-samples/higgs-shop-sample-app/src/components/APIKeyHeaderBar/APIKeyHeaderBar.test.tsx
@@ -1,15 +1,36 @@
-import { render, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
+import { LOCAL_STORAGE_KEY } from '../../constants';
+import { renderWithAPIKeyContext } from '../../test-utils/helpers';
 import APIKeyHeaderBar from './APIKeyHeaderBar';
 
 describe('API Key Header Bar', () => {
+    const OLD_ENV = process.env;
+
+    beforeEach(() => {
+        jest.resetModules();
+        process.env = { ...OLD_ENV };
+
+        window.localStorage.setItem(
+            LOCAL_STORAGE_KEY,
+            JSON.stringify('test_key'),
+        );
+    });
+
+    afterAll(() => {
+        process.env = OLD_ENV;
+        window.localStorage.removeItem(LOCAL_STORAGE_KEY);
+    });
+
     it('should have a valid UI Elements', () => {
-        render(<APIKeyHeaderBar />);
+        process.env.REACT_APP_HOSTED = 'true';
+
+        renderWithAPIKeyContext(<APIKeyHeaderBar />);
 
         const welcomeText = screen.getByText(
             'You are viewing the mParticle Web Sample App',
         );
 
-        const githubRepoLink = screen.getByRole('link', {
+        const githubRepoLink = screen.getByRole('button', {
             name: /learn more/i,
         });
 
@@ -27,5 +48,17 @@ describe('API Key Header Bar', () => {
             'href',
             'https://github.com/mParticle/mparticle-web-sample-apps',
         );
+    });
+
+    it('should not only appear if hosted mode is not enabled', () => {
+        process.env.REACT_APP_HOSTED = undefined;
+
+        renderWithAPIKeyContext(<APIKeyHeaderBar />);
+
+        const welcomeText = screen.queryByText(
+            'You are viewing the mParticle Web Sample App',
+        );
+
+        expect(welcomeText).not.toBeInTheDocument();
     });
 });

--- a/core-sdk-samples/higgs-shop-sample-app/src/components/APIKeyHeaderBar/APIKeyHeaderBar.tsx
+++ b/core-sdk-samples/higgs-shop-sample-app/src/components/APIKeyHeaderBar/APIKeyHeaderBar.tsx
@@ -2,8 +2,11 @@ import { Box, Button, Container, Typography } from '@mui/material';
 import GitHubIcon from '@mui/icons-material/GitHub';
 import KeyIcon from '@mui/icons-material/Key';
 import React from 'react';
+import { useAPIKeyContext } from '../../contexts/APIKeyContext';
 
 const APIKeyHeaderBar: React.FC = () => {
+    const { setModalMode } = useAPIKeyContext();
+
     return (
         <Container
             maxWidth={false}
@@ -36,7 +39,11 @@ const APIKeyHeaderBar: React.FC = () => {
                     Learn more
                 </Button>
             </Box>
-            <Button variant='text' startIcon={<KeyIcon />}>
+            <Button
+                variant='text'
+                startIcon={<KeyIcon />}
+                onClick={() => setModalMode('update')}
+            >
                 Web Key
             </Button>
         </Container>

--- a/core-sdk-samples/higgs-shop-sample-app/src/components/APIKeyHeaderBar/APIKeyHeaderBar.tsx
+++ b/core-sdk-samples/higgs-shop-sample-app/src/components/APIKeyHeaderBar/APIKeyHeaderBar.tsx
@@ -3,9 +3,15 @@ import GitHubIcon from '@mui/icons-material/GitHub';
 import KeyIcon from '@mui/icons-material/Key';
 import React from 'react';
 import { useAPIKeyContext } from '../../contexts/APIKeyContext';
+import useApiKey from '../../hooks/useAPIKey';
 
 const APIKeyHeaderBar: React.FC = () => {
     const { setModalMode } = useAPIKeyContext();
+    const [, isHosted] = useApiKey();
+
+    if (!isHosted) {
+        return <div />;
+    }
 
     return (
         <Container

--- a/core-sdk-samples/higgs-shop-sample-app/src/components/APIKeyHeaderBar/APIKeyHeaderBar.tsx
+++ b/core-sdk-samples/higgs-shop-sample-app/src/components/APIKeyHeaderBar/APIKeyHeaderBar.tsx
@@ -37,6 +37,7 @@ const APIKeyHeaderBar: React.FC = () => {
                     You are viewing the mParticle Web Sample App
                 </Typography>
                 <Button
+                    role='button'
                     variant='text'
                     startIcon={<GitHubIcon />}
                     target='_blank'
@@ -47,6 +48,7 @@ const APIKeyHeaderBar: React.FC = () => {
                 </Button>
             </Box>
             <Button
+                role='button'
                 variant='text'
                 startIcon={<KeyIcon />}
                 onClick={() => setModalMode(MODAL_MODES.UPDATE)}

--- a/core-sdk-samples/higgs-shop-sample-app/src/components/APIKeyHeaderBar/APIKeyHeaderBar.tsx
+++ b/core-sdk-samples/higgs-shop-sample-app/src/components/APIKeyHeaderBar/APIKeyHeaderBar.tsx
@@ -4,6 +4,7 @@ import KeyIcon from '@mui/icons-material/Key';
 import React from 'react';
 import { useAPIKeyContext } from '../../contexts/APIKeyContext';
 import useApiKey from '../../hooks/useAPIKey';
+import { MODAL_MODES } from '../../constants';
 
 const APIKeyHeaderBar: React.FC = () => {
     const { setModalMode } = useAPIKeyContext();
@@ -48,7 +49,7 @@ const APIKeyHeaderBar: React.FC = () => {
             <Button
                 variant='text'
                 startIcon={<KeyIcon />}
-                onClick={() => setModalMode('update')}
+                onClick={() => setModalMode(MODAL_MODES.UPDATE)}
             >
                 Web Key
             </Button>

--- a/core-sdk-samples/higgs-shop-sample-app/src/components/APIKeyModal/APIKeyEntryModal.test.tsx
+++ b/core-sdk-samples/higgs-shop-sample-app/src/components/APIKeyModal/APIKeyEntryModal.test.tsx
@@ -1,9 +1,28 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { screen, fireEvent, waitFor } from '@testing-library/react';
+import { renderWithAPIKeyContext } from '../../test-utils/helpers';
 import APIKeyEntryModal from './APIKeyEntryModal';
 
 describe('API Key Entry Modal', () => {
+    const originalWinLocation = window.location;
+
+    // Mock window location since update modal resets window
+    beforeAll(() => {
+        Object.defineProperty(window, 'location', {
+            configurable: true,
+            value: { reload: jest.fn() },
+        });
+    });
+
+    // Unmock window location
+    afterAll(() => {
+        Object.defineProperty(window, 'location', {
+            configurable: true,
+            value: originalWinLocation,
+        });
+    });
+
     test('renders a modal with necessary UI elements', () => {
-        render(<APIKeyEntryModal />);
+        renderWithAPIKeyContext(<APIKeyEntryModal isOpen />);
 
         const welcomeText = screen.getByText('Welcome to HiggsMart!');
 
@@ -31,7 +50,7 @@ describe('API Key Entry Modal', () => {
     });
 
     test('should enable Save & Go button if API Key is Entered', async () => {
-        render(<APIKeyEntryModal />);
+        renderWithAPIKeyContext(<APIKeyEntryModal isOpen />);
 
         const keyTextField = screen.getByRole('textbox', {
             name: /key/i,
@@ -48,8 +67,8 @@ describe('API Key Entry Modal', () => {
         await waitFor(() => expect(saveAndGoButton).toBeEnabled());
     });
 
-    test('should close only if API Key is entered', async () => {
-        render(<APIKeyEntryModal />);
+    test('should close only if API Key is entered and reload window', async () => {
+        renderWithAPIKeyContext(<APIKeyEntryModal isOpen />);
 
         const keyTextField = screen.getByRole('textbox', {
             name: /key/i,
@@ -67,5 +86,6 @@ describe('API Key Entry Modal', () => {
                 screen.queryByText('Welcome to HiggsMart!'),
             ).not.toBeVisible(),
         );
+        await waitFor(() => expect(window.location.reload).toHaveBeenCalled());
     });
 });

--- a/core-sdk-samples/higgs-shop-sample-app/src/components/APIKeyModal/APIKeyEntryModal.tsx
+++ b/core-sdk-samples/higgs-shop-sample-app/src/components/APIKeyModal/APIKeyEntryModal.tsx
@@ -1,3 +1,5 @@
+// TS incorrectly flags function declarations as unused variables
+/* eslint-disable no-unused-vars */
 import {
     Box,
     Button,
@@ -13,7 +15,11 @@ import {
 import React, { useState } from 'react';
 import { HiggsLogo } from '../HiggsLogo';
 
-const APIKeyEntryModal: React.FC = () => {
+interface APIKeyEntryModalProps {
+    onSetAPIKey?(apiKey: string): void;
+}
+
+const APIKeyEntryModal: React.FC<APIKeyEntryModalProps> = ({ onSetAPIKey }) => {
     const [apiKey, setAPIKey] = useState('');
     const [open, setOpen] = useState(true);
 
@@ -22,6 +28,9 @@ const APIKeyEntryModal: React.FC = () => {
     };
 
     const handleButtonClick = () => {
+        if (onSetAPIKey) {
+            onSetAPIKey(apiKey);
+        }
         closeModal();
     };
 
@@ -115,6 +124,10 @@ const APIKeyEntryModal: React.FC = () => {
             </Grid>
         </Dialog>
     );
+};
+
+APIKeyEntryModal.defaultProps = {
+    onSetAPIKey: undefined,
 };
 
 export default APIKeyEntryModal;

--- a/core-sdk-samples/higgs-shop-sample-app/src/components/APIKeyModal/APIKeyEntryModal.tsx
+++ b/core-sdk-samples/higgs-shop-sample-app/src/components/APIKeyModal/APIKeyEntryModal.tsx
@@ -15,6 +15,7 @@ import {
 import React, { useEffect, useState } from 'react';
 import { HiggsLogo } from '../HiggsLogo';
 import { useAPIKeyContext } from '../../contexts/APIKeyContext';
+import { MODAL_MODES } from '../../constants';
 
 interface APIKeyEntryModalProps {
     isOpen?: boolean;
@@ -27,11 +28,11 @@ const APIKeyEntryModal: React.FC<APIKeyEntryModalProps> = ({ isOpen }) => {
     const { setModalMode, apiKey, setAPIKey } = useAPIKeyContext();
 
     const closeModal = () => {
-        setModalMode('closed');
+        setModalMode(MODAL_MODES.ENTRY);
         setOpen(false);
     };
 
-    const handleButtonClick = () => {
+    const handleSaveButtonClick = () => {
         setAPIKey(currentAPIKey);
         closeModal();
     };
@@ -122,7 +123,7 @@ const APIKeyEntryModal: React.FC<APIKeyEntryModalProps> = ({ isOpen }) => {
                         <Button
                             disabled={!currentAPIKey}
                             variant='contained'
-                            onClick={handleButtonClick}
+                            onClick={handleSaveButtonClick}
                             size='large'
                         >
                             Save &amp; Go

--- a/core-sdk-samples/higgs-shop-sample-app/src/components/APIKeyModal/APIKeyEntryModal.tsx
+++ b/core-sdk-samples/higgs-shop-sample-app/src/components/APIKeyModal/APIKeyEntryModal.tsx
@@ -12,27 +12,33 @@ import {
     TextField,
     FormControl,
 } from '@mui/material';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { HiggsLogo } from '../HiggsLogo';
+import { useAPIKeyContext } from '../../contexts/APIKeyContext';
 
 interface APIKeyEntryModalProps {
-    onSetAPIKey?(apiKey: string): void;
+    isOpen?: boolean;
 }
 
-const APIKeyEntryModal: React.FC<APIKeyEntryModalProps> = ({ onSetAPIKey }) => {
-    const [apiKey, setAPIKey] = useState('');
+const APIKeyEntryModal: React.FC<APIKeyEntryModalProps> = ({ isOpen }) => {
+    const [currentAPIKey, setCurrentAPIKey] = useState('');
     const [open, setOpen] = useState(true);
 
+    const { setModalMode, apiKey, setAPIKey } = useAPIKeyContext();
+
     const closeModal = () => {
+        setModalMode('closed');
         setOpen(false);
     };
 
     const handleButtonClick = () => {
-        if (onSetAPIKey) {
-            onSetAPIKey(apiKey);
-        }
+        setAPIKey(currentAPIKey);
         closeModal();
     };
+
+    useEffect(() => {
+        setOpen(isOpen || false);
+    }, [isOpen]);
 
     return (
         <Dialog open={open}>
@@ -104,7 +110,9 @@ const APIKeyEntryModal: React.FC<APIKeyEntryModalProps> = ({ onSetAPIKey }) => {
                                 id='apiKey'
                                 label='Key'
                                 placeholder='Paste your Key here'
-                                onChange={(e) => setAPIKey(e.target.value)}
+                                onChange={(e) =>
+                                    setCurrentAPIKey(e.target.value)
+                                }
                             />
                         </FormControl>
                     </DialogContent>
@@ -112,7 +120,7 @@ const APIKeyEntryModal: React.FC<APIKeyEntryModalProps> = ({ onSetAPIKey }) => {
                 <Grid item>
                     <DialogActions>
                         <Button
-                            disabled={!apiKey}
+                            disabled={!currentAPIKey}
                             variant='contained'
                             onClick={handleButtonClick}
                             size='large'
@@ -127,7 +135,7 @@ const APIKeyEntryModal: React.FC<APIKeyEntryModalProps> = ({ onSetAPIKey }) => {
 };
 
 APIKeyEntryModal.defaultProps = {
-    onSetAPIKey: undefined,
+    isOpen: false,
 };
 
 export default APIKeyEntryModal;

--- a/core-sdk-samples/higgs-shop-sample-app/src/components/APIKeyModal/APIKeyEntryModal.tsx
+++ b/core-sdk-samples/higgs-shop-sample-app/src/components/APIKeyModal/APIKeyEntryModal.tsx
@@ -22,7 +22,7 @@ interface APIKeyEntryModalProps {
 
 const APIKeyEntryModal: React.FC<APIKeyEntryModalProps> = ({ isOpen }) => {
     const [currentAPIKey, setCurrentAPIKey] = useState('');
-    const [open, setOpen] = useState(true);
+    const [open, setOpen] = useState(false);
 
     const { setModalMode, apiKey, setAPIKey } = useAPIKeyContext();
 

--- a/core-sdk-samples/higgs-shop-sample-app/src/components/APIKeyModal/APIKeyEnvMessageModal.tsx
+++ b/core-sdk-samples/higgs-shop-sample-app/src/components/APIKeyModal/APIKeyEnvMessageModal.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { Button } from '@mui/material';
+import { MessageModal } from '../MessageModal';
+import { APIkeyModalMessage } from '../../constants';
+
+interface APIKeyEnvMessageModalProps {
+    isOpen: boolean;
+}
+
+const APIKeyEnvMessageModal: React.FC<APIKeyEnvMessageModalProps> = ({
+    isOpen,
+}) => {
+    return (
+        <MessageModal
+            message={APIkeyModalMessage}
+            open={isOpen}
+            buttonAction={
+                <>
+                    <Button
+                        variant='contained'
+                        target='_blank'
+                        href='https://github.com/mParticle/mparticle-web-sample-apps/blob/main/core-sdk-samples/higgs-shop-sample-app/README.md'
+                    >
+                        Go to Readme
+                    </Button>
+                    <Button
+                        variant='contained'
+                        target='_blank'
+                        href='https://docs.mparticle.com/developers/quickstart/senddata/#1-generate-your-api-key-2'
+                    >
+                        Go to Docs
+                    </Button>
+                </>
+            }
+        />
+    );
+};
+
+export default APIKeyEnvMessageModal;

--- a/core-sdk-samples/higgs-shop-sample-app/src/components/APIKeyModal/APIKeyRemoveConfirmationModal.test.tsx
+++ b/core-sdk-samples/higgs-shop-sample-app/src/components/APIKeyModal/APIKeyRemoveConfirmationModal.test.tsx
@@ -1,9 +1,10 @@
-import { render, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
+import { renderWithAPIKeyContext } from '../../test-utils/helpers';
 import APIKeyRemoveConfirmationModal from './APIKeyRemoveConfirmationModal';
 
 describe('API Key Remove Confirmation Modal', () => {
     test('renders a modal with necessary UI elements', () => {
-        render(<APIKeyRemoveConfirmationModal />);
+        renderWithAPIKeyContext(<APIKeyRemoveConfirmationModal isOpen />);
 
         const headerText = screen.getByText('Are you sure?');
 

--- a/core-sdk-samples/higgs-shop-sample-app/src/components/APIKeyModal/APIKeyRemoveConfirmationModal.tsx
+++ b/core-sdk-samples/higgs-shop-sample-app/src/components/APIKeyModal/APIKeyRemoveConfirmationModal.tsx
@@ -7,6 +7,7 @@ import {
     Typography,
 } from '@mui/material';
 import React, { useEffect, useState } from 'react';
+import { MODAL_MODES } from '../../constants';
 import { useAPIKeyContext } from '../../contexts/APIKeyContext';
 
 interface APIKeyRemoveConfirmationModalProps {
@@ -22,12 +23,12 @@ const APIKeyRemoveConfirmationModal: React.FC<
 
     const handleRemoveKeyClick = () => {
         removeAPIKey();
-        setModalMode('closed');
+        setModalMode(MODAL_MODES.CLOSED);
         setOpen(false);
     };
 
     const handleBackClick = () => {
-        setModalMode('update');
+        setModalMode(MODAL_MODES.UPDATE);
         setOpen(false);
     };
 

--- a/core-sdk-samples/higgs-shop-sample-app/src/components/APIKeyModal/APIKeyRemoveConfirmationModal.tsx
+++ b/core-sdk-samples/higgs-shop-sample-app/src/components/APIKeyModal/APIKeyRemoveConfirmationModal.tsx
@@ -6,10 +6,35 @@ import {
     Grid,
     Typography,
 } from '@mui/material';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
+import { useAPIKeyContext } from '../../contexts/APIKeyContext';
 
-const APIKeyRemoveConfirmationModal: React.FC = () => {
-    const [open, setOpen] = useState(true);
+interface APIKeyRemoveConfirmationModalProps {
+    isOpen?: boolean;
+}
+
+const APIKeyRemoveConfirmationModal: React.FC<
+    APIKeyRemoveConfirmationModalProps
+> = ({ isOpen }) => {
+    const [open, setOpen] = useState(false);
+
+    const { setAPIKey, setModalMode } = useAPIKeyContext();
+
+    const handleRemoveKeyClick = () => {
+        setAPIKey('');
+        setModalMode('closed');
+        setOpen(false);
+    };
+
+    const handleBackClick = () => {
+        setModalMode('update');
+        setOpen(false);
+    };
+
+    useEffect(() => {
+        setOpen(isOpen || false);
+    }, [isOpen]);
+
     return (
         <Dialog open={open}>
             <Grid
@@ -41,7 +66,12 @@ const APIKeyRemoveConfirmationModal: React.FC = () => {
                 </Grid>
                 <Grid item>
                     <DialogActions>
-                        <Button variant='contained' color='error' size='large'>
+                        <Button
+                            variant='contained'
+                            color='error'
+                            size='large'
+                            onClick={handleRemoveKeyClick}
+                        >
                             Remove key &amp; reset app
                         </Button>
                     </DialogActions>
@@ -51,7 +81,7 @@ const APIKeyRemoveConfirmationModal: React.FC = () => {
                         <Button
                             variant='text'
                             size='large'
-                            onClick={() => setOpen(false)}
+                            onClick={handleBackClick}
                         >
                             Back
                         </Button>
@@ -60,6 +90,10 @@ const APIKeyRemoveConfirmationModal: React.FC = () => {
             </Grid>
         </Dialog>
     );
+};
+
+APIKeyRemoveConfirmationModal.defaultProps = {
+    isOpen: false,
 };
 
 export default APIKeyRemoveConfirmationModal;

--- a/core-sdk-samples/higgs-shop-sample-app/src/components/APIKeyModal/APIKeyRemoveConfirmationModal.tsx
+++ b/core-sdk-samples/higgs-shop-sample-app/src/components/APIKeyModal/APIKeyRemoveConfirmationModal.tsx
@@ -18,10 +18,10 @@ const APIKeyRemoveConfirmationModal: React.FC<
 > = ({ isOpen }) => {
     const [open, setOpen] = useState(false);
 
-    const { setAPIKey, setModalMode } = useAPIKeyContext();
+    const { setModalMode, removeAPIKey } = useAPIKeyContext();
 
     const handleRemoveKeyClick = () => {
-        setAPIKey('');
+        removeAPIKey();
         setModalMode('closed');
         setOpen(false);
     };

--- a/core-sdk-samples/higgs-shop-sample-app/src/components/APIKeyModal/APIKeyUpdateModal.test.tsx
+++ b/core-sdk-samples/higgs-shop-sample-app/src/components/APIKeyModal/APIKeyUpdateModal.test.tsx
@@ -3,7 +3,7 @@ import APIKeyUpdateModal from './APIKeyUpdateModal';
 
 describe('API Key Update Modal', () => {
     test('renders a modal with necessary UI elements', () => {
-        render(<APIKeyUpdateModal currentApiKey='XXXXX' />);
+        render(<APIKeyUpdateModal />);
 
         const header = screen.queryByText('Web Key');
 
@@ -42,7 +42,7 @@ describe('API Key Update Modal', () => {
     });
 
     test('should enable Update button if API Key is Changed', async () => {
-        render(<APIKeyUpdateModal currentApiKey='XXXXX' />);
+        render(<APIKeyUpdateModal />);
 
         const keyTextField = screen.getByRole('textbox', {
             name: /key/i,
@@ -60,7 +60,7 @@ describe('API Key Update Modal', () => {
     });
 
     test('should close Cancel is clicked', async () => {
-        render(<APIKeyUpdateModal currentApiKey='XXXXX' />);
+        render(<APIKeyUpdateModal />);
 
         expect(screen.queryByText('Web Key')).toBeInTheDocument();
 
@@ -81,7 +81,7 @@ describe('API Key Update Modal', () => {
     });
 
     test('should close if API Key is updated', async () => {
-        render(<APIKeyUpdateModal currentApiKey='XXXXX' />);
+        render(<APIKeyUpdateModal />);
 
         const keyTextField = screen.getByRole('textbox', {
             name: /key/i,

--- a/core-sdk-samples/higgs-shop-sample-app/src/components/APIKeyModal/APIKeyUpdateModal.test.tsx
+++ b/core-sdk-samples/higgs-shop-sample-app/src/components/APIKeyModal/APIKeyUpdateModal.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import APIKeyContextProvider from '../../contexts/APIKeyContext';
+import { renderWithAPIKeyContext } from '../../test-utils/helpers';
 import APIKeyUpdateModal from './APIKeyUpdateModal';
 
 describe('API Key Update Modal', () => {
@@ -22,11 +23,7 @@ describe('API Key Update Modal', () => {
     });
 
     test('renders a modal with necessary UI elements', () => {
-        render(
-            <APIKeyContextProvider>
-                <APIKeyUpdateModal isOpen />
-            </APIKeyContextProvider>,
-        );
+        renderWithAPIKeyContext(<APIKeyUpdateModal isOpen />);
 
         const header = screen.queryByText('Web Key');
 
@@ -65,11 +62,7 @@ describe('API Key Update Modal', () => {
     });
 
     test('should enable Update button if API Key is Changed', async () => {
-        render(
-            <APIKeyContextProvider>
-                <APIKeyUpdateModal isOpen />
-            </APIKeyContextProvider>,
-        );
+        renderWithAPIKeyContext(<APIKeyUpdateModal isOpen />);
 
         const keyTextField = screen.getByRole('textbox', {
             name: /key/i,
@@ -87,11 +80,7 @@ describe('API Key Update Modal', () => {
     });
 
     test('should close when Cancel is clicked', async () => {
-        render(
-            <APIKeyContextProvider>
-                <APIKeyUpdateModal isOpen />
-            </APIKeyContextProvider>,
-        );
+        renderWithAPIKeyContext(<APIKeyUpdateModal isOpen />);
 
         expect(screen.queryByText('Web Key')).toBeInTheDocument();
 
@@ -112,11 +101,7 @@ describe('API Key Update Modal', () => {
     });
 
     test('should close when API Key is updated', async () => {
-        render(
-            <APIKeyContextProvider>
-                <APIKeyUpdateModal isOpen />
-            </APIKeyContextProvider>,
-        );
+        renderWithAPIKeyContext(<APIKeyUpdateModal isOpen />);
 
         const keyTextField = screen.getByRole('textbox', {
             name: /key/i,
@@ -140,11 +125,7 @@ describe('API Key Update Modal', () => {
     });
 
     test('should reload window when API Key is updated', async () => {
-        render(
-            <APIKeyContextProvider>
-                <APIKeyUpdateModal isOpen />
-            </APIKeyContextProvider>,
-        );
+        renderWithAPIKeyContext(<APIKeyUpdateModal isOpen />);
 
         const keyTextField = screen.getByRole('textbox', {
             name: /key/i,

--- a/core-sdk-samples/higgs-shop-sample-app/src/components/APIKeyModal/APIKeyUpdateModal.test.tsx
+++ b/core-sdk-samples/higgs-shop-sample-app/src/components/APIKeyModal/APIKeyUpdateModal.test.tsx
@@ -1,5 +1,4 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import APIKeyContextProvider from '../../contexts/APIKeyContext';
+import { screen, fireEvent, waitFor } from '@testing-library/react';
 import { renderWithAPIKeyContext } from '../../test-utils/helpers';
 import APIKeyUpdateModal from './APIKeyUpdateModal';
 

--- a/core-sdk-samples/higgs-shop-sample-app/src/components/APIKeyModal/APIKeyUpdateModal.test.tsx
+++ b/core-sdk-samples/higgs-shop-sample-app/src/components/APIKeyModal/APIKeyUpdateModal.test.tsx
@@ -1,9 +1,32 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import APIKeyContextProvider from '../../contexts/APIKeyContext';
 import APIKeyUpdateModal from './APIKeyUpdateModal';
 
 describe('API Key Update Modal', () => {
+    const originalWinLocation = window.location;
+
+    // Mock window location since update modal resets window
+    beforeAll(() => {
+        Object.defineProperty(window, 'location', {
+            configurable: true,
+            value: { reload: jest.fn() },
+        });
+    });
+
+    // Unmock window location
+    afterAll(() => {
+        Object.defineProperty(window, 'location', {
+            configurable: true,
+            value: originalWinLocation,
+        });
+    });
+
     test('renders a modal with necessary UI elements', () => {
-        render(<APIKeyUpdateModal />);
+        render(
+            <APIKeyContextProvider>
+                <APIKeyUpdateModal isOpen />
+            </APIKeyContextProvider>,
+        );
 
         const header = screen.queryByText('Web Key');
 
@@ -34,7 +57,7 @@ describe('API Key Update Modal', () => {
             'https://docs.mparticle.com/guides/getting-started/create-an-input/#create-access-credentials',
         );
         expect(keyTextField).toBeInTheDocument();
-        expect(keyTextField).toHaveAttribute('value', 'XXXXX');
+        expect(keyTextField).toHaveAttribute('value', 'test_key');
         expect(updateButton).toBeInTheDocument();
         expect(updateButton).toBeDisabled();
         expect(removeKeyButton).toBeInTheDocument();
@@ -42,7 +65,11 @@ describe('API Key Update Modal', () => {
     });
 
     test('should enable Update button if API Key is Changed', async () => {
-        render(<APIKeyUpdateModal />);
+        render(
+            <APIKeyContextProvider>
+                <APIKeyUpdateModal isOpen />
+            </APIKeyContextProvider>,
+        );
 
         const keyTextField = screen.getByRole('textbox', {
             name: /key/i,
@@ -59,8 +86,12 @@ describe('API Key Update Modal', () => {
         await waitFor(() => expect(updateButton).toBeEnabled());
     });
 
-    test('should close Cancel is clicked', async () => {
-        render(<APIKeyUpdateModal />);
+    test('should close when Cancel is clicked', async () => {
+        render(
+            <APIKeyContextProvider>
+                <APIKeyUpdateModal isOpen />
+            </APIKeyContextProvider>,
+        );
 
         expect(screen.queryByText('Web Key')).toBeInTheDocument();
 
@@ -80,8 +111,12 @@ describe('API Key Update Modal', () => {
         );
     });
 
-    test('should close if API Key is updated', async () => {
-        render(<APIKeyUpdateModal />);
+    test('should close when API Key is updated', async () => {
+        render(
+            <APIKeyContextProvider>
+                <APIKeyUpdateModal isOpen />
+            </APIKeyContextProvider>,
+        );
 
         const keyTextField = screen.getByRole('textbox', {
             name: /key/i,
@@ -102,5 +137,29 @@ describe('API Key Update Modal', () => {
         await waitFor(() =>
             expect(screen.queryByText('Web Key')).not.toBeVisible(),
         );
+    });
+
+    test('should reload window when API Key is updated', async () => {
+        render(
+            <APIKeyContextProvider>
+                <APIKeyUpdateModal isOpen />
+            </APIKeyContextProvider>,
+        );
+
+        const keyTextField = screen.getByRole('textbox', {
+            name: /key/i,
+        });
+
+        const updateButton = screen.getByRole('button', {
+            name: 'Update',
+        });
+
+        fireEvent.change(keyTextField, { target: { value: 'YYYYYYYYY' } });
+
+        await waitFor(() => expect(updateButton).toBeEnabled());
+
+        fireEvent.click(updateButton);
+
+        await waitFor(() => expect(window.location.reload).toHaveBeenCalled());
     });
 });

--- a/core-sdk-samples/higgs-shop-sample-app/src/components/APIKeyModal/APIKeyUpdateModal.tsx
+++ b/core-sdk-samples/higgs-shop-sample-app/src/components/APIKeyModal/APIKeyUpdateModal.tsx
@@ -15,19 +15,15 @@ import { HiggsLogo } from '../HiggsLogo';
 import { useAPIKeyContext } from '../../contexts/APIKeyContext';
 
 interface APIKeyUpdateModalProps {
-    currentApiKey: string;
     isOpen?: boolean;
 }
 
-const APIKeyUpdateModal: React.FC<APIKeyUpdateModalProps> = ({
-    currentApiKey,
-    isOpen,
-}) => {
-    const [NewAPIKey, setNewAPIKey] = useState(currentApiKey);
+const APIKeyUpdateModal: React.FC<APIKeyUpdateModalProps> = ({ isOpen }) => {
+    const { apiKey, setAPIKey, setModalMode } = useAPIKeyContext();
+
+    const [currentAPIKey, setCurrentAPIKey] = useState(apiKey);
     const [open, setOpen] = useState(false);
     const [canUpdateAPIKey, setCanUpdateAPIKey] = useState(false);
-
-    const { setAPIKey, setModalMode } = useAPIKeyContext();
 
     const closeModal = () => {
         setModalMode('closed');
@@ -35,29 +31,29 @@ const APIKeyUpdateModal: React.FC<APIKeyUpdateModalProps> = ({
     };
 
     const handleAPIKeyUpdate = (e: React.ChangeEvent<HTMLInputElement>) => {
-        setNewAPIKey(e.target.value);
-        if (e.target.value === '' || e.target.value === currentApiKey) {
+        setCurrentAPIKey(e.target.value);
+        if (e.target.value === '' || e.target.value === currentAPIKey) {
             setCanUpdateAPIKey(false);
         } else {
             setCanUpdateAPIKey(true);
         }
     };
 
-    const handleButtonClick = () => {
-        // TODO: Pass API Key to parent
-        setAPIKey(NewAPIKey);
+    const handleUpdateClick = () => {
+        setAPIKey(currentAPIKey);
         closeModal();
     };
 
+    // TODO: Can we remove this?
     useEffect(() => {
-        console.log('peekaboo');
         // Reset to current api key upon open
-        setNewAPIKey(currentApiKey);
+        setCurrentAPIKey(apiKey);
     }, [open]);
 
+    // TODO: Can we remove this?
     useEffect(() => {
-        console.log('update: api key changed', currentApiKey);
-    }, [currentApiKey]);
+        setCurrentAPIKey(apiKey);
+    }, [apiKey]);
 
     useEffect(() => {
         setOpen(isOpen || false);
@@ -117,13 +113,15 @@ const APIKeyUpdateModal: React.FC<APIKeyUpdateModalProps> = ({
                     <DialogContent>
                         <FormControl fullWidth focused required>
                             <TextField
-                                error={!NewAPIKey}
+                                error={!currentAPIKey}
                                 id='apiKey'
                                 label='Key'
-                                value={NewAPIKey}
+                                value={currentAPIKey}
                                 placeholder='Paste your Key here'
                                 onChange={handleAPIKeyUpdate}
-                                helperText={!NewAPIKey ? 'Key is required' : ''}
+                                helperText={
+                                    !currentAPIKey ? 'Key is required' : ''
+                                }
                             />
                         </FormControl>
                     </DialogContent>
@@ -131,7 +129,7 @@ const APIKeyUpdateModal: React.FC<APIKeyUpdateModalProps> = ({
                 <Grid item>
                     <DialogActions>
                         <Button
-                            disabled={!NewAPIKey}
+                            disabled={!currentAPIKey}
                             variant='contained'
                             color='error'
                             size='large'
@@ -142,7 +140,7 @@ const APIKeyUpdateModal: React.FC<APIKeyUpdateModalProps> = ({
                         <Button
                             disabled={!canUpdateAPIKey}
                             variant='contained'
-                            onClick={handleButtonClick}
+                            onClick={handleUpdateClick}
                             size='large'
                         >
                             Update

--- a/core-sdk-samples/higgs-shop-sample-app/src/components/APIKeyModal/APIKeyUpdateModal.tsx
+++ b/core-sdk-samples/higgs-shop-sample-app/src/components/APIKeyModal/APIKeyUpdateModal.tsx
@@ -1,3 +1,11 @@
+/**
+ * Sample App UI Component
+ *
+ * The the code in this file is purely for Sample App functionality and presentation
+ * and does not in any way reflect how mParticle actually works in a production or
+ * 'real world' application
+ */
+
 import {
     Box,
     Button,
@@ -20,9 +28,14 @@ interface APIKeyUpdateModalProps {
 }
 
 const APIKeyUpdateModal: React.FC<APIKeyUpdateModalProps> = ({ isOpen }) => {
-    const { apiKey, setAPIKey, setModalMode } = useAPIKeyContext();
+    const {
+        // Change attributes to provide more clarity
+        apiKey: globalAPIKey,
+        setAPIKey: setGlobalAPIKey,
+        setModalMode,
+    } = useAPIKeyContext();
 
-    const [currentAPIKey, setCurrentAPIKey] = useState(apiKey);
+    const [tempAPIKey, setTempAPIKey] = useState(globalAPIKey);
     const [open, setOpen] = useState(false);
     const [canUpdateAPIKey, setCanUpdateAPIKey] = useState(false);
 
@@ -32,8 +45,12 @@ const APIKeyUpdateModal: React.FC<APIKeyUpdateModalProps> = ({ isOpen }) => {
     };
 
     const handleAPIKeyUpdate = (e: React.ChangeEvent<HTMLInputElement>) => {
-        setCurrentAPIKey(e.target.value);
-        if (e.target.value === '' || e.target.value === apiKey) {
+        // Checks if the Update Button should be enabled by comparing the
+        // component level `tempAPIKey` with the application's `apiKey`
+        // If they match, then the api key has not changed and should not be
+        // updated
+        setTempAPIKey(e.target.value);
+        if (e.target.value === '' || e.target.value === globalAPIKey) {
             setCanUpdateAPIKey(false);
         } else {
             setCanUpdateAPIKey(true);
@@ -41,19 +58,24 @@ const APIKeyUpdateModal: React.FC<APIKeyUpdateModalProps> = ({ isOpen }) => {
     };
 
     const handleUpdateClick = () => {
-        if (currentAPIKey) {
-            setAPIKey(currentAPIKey);
+        // Closes the modal only if api key has been updated
+        // Button will be disabled if api key has not changed
+        if (tempAPIKey) {
+            setGlobalAPIKey(tempAPIKey);
             closeModal();
         }
     };
 
     useEffect(() => {
-        // Reset to current api key upon open
-        setCurrentAPIKey(apiKey);
+        // Reset the api key in the ui component back to whatever is currently in
+        // the application state
+        setTempAPIKey(globalAPIKey);
         setCanUpdateAPIKey(false);
     }, [open]);
 
     useEffect(() => {
+        // Listens for the `isOpen` state to make sure
+        // component stays closed when it isn't needed
         setOpen(isOpen || false);
     }, [isOpen]);
 
@@ -111,14 +133,14 @@ const APIKeyUpdateModal: React.FC<APIKeyUpdateModalProps> = ({ isOpen }) => {
                     <DialogContent>
                         <FormControl fullWidth focused required>
                             <TextField
-                                error={!currentAPIKey}
+                                error={!tempAPIKey}
                                 id='apiKey'
                                 label='Key'
-                                value={currentAPIKey}
+                                value={tempAPIKey}
                                 placeholder='Paste your Key here'
                                 onChange={handleAPIKeyUpdate}
                                 helperText={
-                                    !currentAPIKey ? 'Key is required' : ''
+                                    !tempAPIKey ? 'Key is required' : ''
                                 }
                             />
                         </FormControl>
@@ -127,7 +149,7 @@ const APIKeyUpdateModal: React.FC<APIKeyUpdateModalProps> = ({ isOpen }) => {
                 <Grid item>
                     <DialogActions>
                         <Button
-                            disabled={!currentAPIKey}
+                            disabled={!tempAPIKey}
                             variant='contained'
                             color='error'
                             size='large'

--- a/core-sdk-samples/higgs-shop-sample-app/src/components/APIKeyModal/APIKeyUpdateModal.tsx
+++ b/core-sdk-samples/higgs-shop-sample-app/src/components/APIKeyModal/APIKeyUpdateModal.tsx
@@ -13,6 +13,7 @@ import {
 import React, { useEffect, useState } from 'react';
 import { HiggsLogo } from '../HiggsLogo';
 import { useAPIKeyContext } from '../../contexts/APIKeyContext';
+import { MODAL_MODES } from '../../constants';
 
 interface APIKeyUpdateModalProps {
     isOpen?: boolean;
@@ -26,13 +27,13 @@ const APIKeyUpdateModal: React.FC<APIKeyUpdateModalProps> = ({ isOpen }) => {
     const [canUpdateAPIKey, setCanUpdateAPIKey] = useState(false);
 
     const closeModal = () => {
-        setModalMode('closed');
+        setModalMode(MODAL_MODES.CLOSED);
         setOpen(false);
     };
 
     const handleAPIKeyUpdate = (e: React.ChangeEvent<HTMLInputElement>) => {
         setCurrentAPIKey(e.target.value);
-        if (e.target.value === '' || e.target.value === currentAPIKey) {
+        if (e.target.value === '' || e.target.value === apiKey) {
             setCanUpdateAPIKey(false);
         } else {
             setCanUpdateAPIKey(true);
@@ -40,20 +41,17 @@ const APIKeyUpdateModal: React.FC<APIKeyUpdateModalProps> = ({ isOpen }) => {
     };
 
     const handleUpdateClick = () => {
-        setAPIKey(currentAPIKey);
-        closeModal();
+        if (currentAPIKey) {
+            setAPIKey(currentAPIKey);
+            closeModal();
+        }
     };
 
-    // TODO: Can we remove this?
     useEffect(() => {
         // Reset to current api key upon open
         setCurrentAPIKey(apiKey);
+        setCanUpdateAPIKey(false);
     }, [open]);
-
-    // TODO: Can we remove this?
-    useEffect(() => {
-        setCurrentAPIKey(apiKey);
-    }, [apiKey]);
 
     useEffect(() => {
         setOpen(isOpen || false);
@@ -99,7 +97,7 @@ const APIKeyUpdateModal: React.FC<APIKeyUpdateModalProps> = ({ isOpen }) => {
                     <DialogContent>
                         <Typography variant='body1' align='center'>
                             The web key should be generated in mParticle in
-                            order to connect this sample app to your account.
+                            order to connect this sample app to your account.{' '}
                             <Link
                                 href='https://docs.mparticle.com/guides/getting-started/create-an-input/#create-access-credentials'
                                 target='_blank'
@@ -133,7 +131,7 @@ const APIKeyUpdateModal: React.FC<APIKeyUpdateModalProps> = ({ isOpen }) => {
                             variant='contained'
                             color='error'
                             size='large'
-                            onClick={() => setModalMode('confirm')}
+                            onClick={() => setModalMode(MODAL_MODES.CONFIRM)}
                         >
                             Remove Key
                         </Button>

--- a/core-sdk-samples/higgs-shop-sample-app/src/components/APIKeyModal/APIKeyUpdateModal.tsx
+++ b/core-sdk-samples/higgs-shop-sample-app/src/components/APIKeyModal/APIKeyUpdateModal.tsx
@@ -10,26 +10,32 @@ import {
     TextField,
     FormControl,
 } from '@mui/material';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { HiggsLogo } from '../HiggsLogo';
+import { useAPIKeyContext } from '../../contexts/APIKeyContext';
 
 interface APIKeyUpdateModalProps {
     currentApiKey: string;
+    isOpen?: boolean;
 }
 
 const APIKeyUpdateModal: React.FC<APIKeyUpdateModalProps> = ({
     currentApiKey,
+    isOpen,
 }) => {
-    const [apiKey, setAPIKey] = useState(currentApiKey);
-    const [open, setOpen] = useState(true);
+    const [NewAPIKey, setNewAPIKey] = useState(currentApiKey);
+    const [open, setOpen] = useState(false);
     const [canUpdateAPIKey, setCanUpdateAPIKey] = useState(false);
 
+    const { setAPIKey, setModalMode } = useAPIKeyContext();
+
     const closeModal = () => {
+        setModalMode('closed');
         setOpen(false);
     };
 
     const handleAPIKeyUpdate = (e: React.ChangeEvent<HTMLInputElement>) => {
-        setAPIKey(e.target.value);
+        setNewAPIKey(e.target.value);
         if (e.target.value === '' || e.target.value === currentApiKey) {
             setCanUpdateAPIKey(false);
         } else {
@@ -39,8 +45,23 @@ const APIKeyUpdateModal: React.FC<APIKeyUpdateModalProps> = ({
 
     const handleButtonClick = () => {
         // TODO: Pass API Key to parent
+        setAPIKey(NewAPIKey);
         closeModal();
     };
+
+    useEffect(() => {
+        console.log('peekaboo');
+        // Reset to current api key upon open
+        setNewAPIKey(currentApiKey);
+    }, [open]);
+
+    useEffect(() => {
+        console.log('update: api key changed', currentApiKey);
+    }, [currentApiKey]);
+
+    useEffect(() => {
+        setOpen(isOpen || false);
+    }, [isOpen]);
 
     return (
         <Dialog open={open}>
@@ -96,13 +117,13 @@ const APIKeyUpdateModal: React.FC<APIKeyUpdateModalProps> = ({
                     <DialogContent>
                         <FormControl fullWidth focused required>
                             <TextField
-                                error={!apiKey}
+                                error={!NewAPIKey}
                                 id='apiKey'
                                 label='Key'
-                                value={apiKey}
+                                value={NewAPIKey}
                                 placeholder='Paste your Key here'
                                 onChange={handleAPIKeyUpdate}
-                                helperText={!apiKey ? 'Key is required' : ''}
+                                helperText={!NewAPIKey ? 'Key is required' : ''}
                             />
                         </FormControl>
                     </DialogContent>
@@ -110,10 +131,11 @@ const APIKeyUpdateModal: React.FC<APIKeyUpdateModalProps> = ({
                 <Grid item>
                     <DialogActions>
                         <Button
-                            disabled={!apiKey}
+                            disabled={!NewAPIKey}
                             variant='contained'
                             color='error'
                             size='large'
+                            onClick={() => setModalMode('confirm')}
                         >
                             Remove Key
                         </Button>
@@ -131,7 +153,7 @@ const APIKeyUpdateModal: React.FC<APIKeyUpdateModalProps> = ({
                     <DialogActions>
                         <Button
                             variant='text'
-                            onClick={() => setOpen(false)}
+                            onClick={closeModal}
                             size='large'
                         >
                             Cancel
@@ -141,6 +163,10 @@ const APIKeyUpdateModal: React.FC<APIKeyUpdateModalProps> = ({
             </Grid>
         </Dialog>
     );
+};
+
+APIKeyUpdateModal.defaultProps = {
+    isOpen: false,
 };
 
 export default APIKeyUpdateModal;

--- a/core-sdk-samples/higgs-shop-sample-app/src/components/APIKeyModal/index.tsx
+++ b/core-sdk-samples/higgs-shop-sample-app/src/components/APIKeyModal/index.tsx
@@ -1,7 +1,9 @@
 export { default as APIKeyEntryModal } from './APIKeyEntryModal';
 export { default as APIKeyUpdateModal } from './APIKeyUpdateModal';
 export { default as APIKeyRemoveConfirmationModal } from './APIKeyRemoveConfirmationModal';
+export { default as APIKeyEnvMessageModal } from './APIKeyEnvMessageModal';
 
 export * from './APIKeyEntryModal';
 export * from './APIKeyUpdateModal';
 export * from './APIKeyRemoveConfirmationModal';
+export * from './APIKeyEnvMessageModal';

--- a/core-sdk-samples/higgs-shop-sample-app/src/components/NavigationMenu/NavigationMenu.test.tsx
+++ b/core-sdk-samples/higgs-shop-sample-app/src/components/NavigationMenu/NavigationMenu.test.tsx
@@ -4,6 +4,17 @@ import { MemoryRouter } from 'react-router-dom';
 import { NavigationMenu } from '.';
 
 describe('Navigation Menu', () => {
+    const OLD_ENV = process.env;
+
+    beforeEach(() => {
+        jest.resetModules();
+        process.env = { ...OLD_ENV };
+    });
+
+    afterAll(() => {
+        process.env = OLD_ENV;
+    });
+
     test('renders a desktop navigation Menu', () => {
         render(<NavigationMenu />, { wrapper: MemoryRouter });
 
@@ -78,6 +89,8 @@ describe('Navigation Menu', () => {
 
     test('renders api key UI Elements', async () => {
         render(<NavigationMenu />, { wrapper: MemoryRouter });
+
+        process.env.REACT_APP_HOSTED = 'true';
 
         const hamburgerButton = screen.getByTestId(
             'mobile-nav-hamburger-button',

--- a/core-sdk-samples/higgs-shop-sample-app/src/components/NavigationMenu/NavigationMenu.tsx
+++ b/core-sdk-samples/higgs-shop-sample-app/src/components/NavigationMenu/NavigationMenu.tsx
@@ -24,9 +24,14 @@ import NavigationMenuDrawer from './NavigationMenuDrawer';
 import HiggsmartLogo from '../HiggsLogo/HiggsmartLogo';
 import theme from '../../contexts/theme';
 import { useOrderDetails } from '../../contexts/OrderDetails';
+import useApiKey from '../../hooks/useAPIKey';
+import { useAPIKeyContext } from '../../contexts/APIKeyContext';
 
 const NavigationMenu: React.FC = () => {
     const { numberOfProducts } = useOrderDetails();
+    const { setModalMode } = useAPIKeyContext();
+    const [, isHosted] = useApiKey();
+
     const classes: SxProps<Theme> = {
         appBar: {},
         drawer: {},
@@ -268,7 +273,7 @@ const NavigationMenu: React.FC = () => {
         <MenuItem
             key='web-key'
             sx={classes.drawerLink}
-            // TODO: Wire this into API Key Modal
+            onClick={() => setModalMode('update')}
         >
             Web Key
         </MenuItem>,
@@ -298,9 +303,11 @@ const NavigationMenu: React.FC = () => {
                             {drawerMenuItems}
                         </MenuList>
 
-                        <MenuList sx={classes.lowerDrawerList}>
-                            {lowerDrawerMenuItems}
-                        </MenuList>
+                        {isHosted && (
+                            <MenuList sx={classes.lowerDrawerList}>
+                                {lowerDrawerMenuItems}
+                            </MenuList>
+                        )}
                     </Box>
                 </NavigationMenuDrawer>
                 <Toolbar disableGutters>

--- a/core-sdk-samples/higgs-shop-sample-app/src/components/NavigationMenu/NavigationMenu.tsx
+++ b/core-sdk-samples/higgs-shop-sample-app/src/components/NavigationMenu/NavigationMenu.tsx
@@ -26,6 +26,7 @@ import theme from '../../contexts/theme';
 import { useOrderDetails } from '../../contexts/OrderDetails';
 import useApiKey from '../../hooks/useAPIKey';
 import { useAPIKeyContext } from '../../contexts/APIKeyContext';
+import { MODAL_MODES } from '../../constants';
 
 const NavigationMenu: React.FC = () => {
     const { numberOfProducts } = useOrderDetails();
@@ -273,7 +274,7 @@ const NavigationMenu: React.FC = () => {
         <MenuItem
             key='web-key'
             sx={classes.drawerLink}
-            onClick={() => setModalMode('update')}
+            onClick={() => setModalMode(MODAL_MODES.UPDATE)}
         >
             Web Key
         </MenuItem>,

--- a/core-sdk-samples/higgs-shop-sample-app/src/components/StartShoppingModal/StartShoppingModal.test.tsx
+++ b/core-sdk-samples/higgs-shop-sample-app/src/components/StartShoppingModal/StartShoppingModal.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import mParticle from '@mparticle/web-sdk';
 import StartShoppingModal from './StartShoppingModal';
 import App from '../../layouts/App';
+import { renderWithAPIKeyContext } from '../../test-utils/helpers';
 
 describe('Start Shopping Modal', () => {
     beforeEach(() => {
@@ -9,7 +10,7 @@ describe('Start Shopping Modal', () => {
     });
 
     test('should have a start shopping button', () => {
-        render(<StartShoppingModal />);
+        renderWithAPIKeyContext(<StartShoppingModal />);
 
         const startShoppingButton = screen.getByRole('button', {
             name: /start shopping/i,
@@ -19,7 +20,7 @@ describe('Start Shopping Modal', () => {
     });
 
     test('should not re-appear after button is clicked', () => {
-        render(<StartShoppingModal />);
+        renderWithAPIKeyContext(<StartShoppingModal />);
 
         const startShoppingButton = screen.getByRole('button', {
             name: /start shopping/i,
@@ -29,13 +30,13 @@ describe('Start Shopping Modal', () => {
 
         expect(startShoppingButton).not.toBeVisible();
 
-        render(<StartShoppingModal />);
+        renderWithAPIKeyContext(<StartShoppingModal />);
 
         expect(startShoppingButton).not.toBeVisible();
     });
 
     test('fires an mParticle Page View when it appears', () => {
-        render(<StartShoppingModal />);
+        renderWithAPIKeyContext(<StartShoppingModal />);
 
         expect(mParticle.logPageView).toHaveBeenCalledWith('Landing');
 
@@ -43,7 +44,7 @@ describe('Start Shopping Modal', () => {
     });
 
     test('fires an mParticle custom event when button is clicked', () => {
-        render(<StartShoppingModal />);
+        renderWithAPIKeyContext(<StartShoppingModal />);
 
         const startShoppingButton = screen.getByRole('button', {
             name: /start shopping/i,

--- a/core-sdk-samples/higgs-shop-sample-app/src/components/StartShoppingModal/StartShoppingModal.tsx
+++ b/core-sdk-samples/higgs-shop-sample-app/src/components/StartShoppingModal/StartShoppingModal.tsx
@@ -46,7 +46,7 @@ const StartShoppingModal: React.FC = () => {
         } else {
             setOpen(false);
         }
-    }, [modalMode, open]);
+    }, [modalMode]);
 
     return (
         <Dialog open={open} onClose={handleBackgroundClick}>

--- a/core-sdk-samples/higgs-shop-sample-app/src/components/StartShoppingModal/StartShoppingModal.tsx
+++ b/core-sdk-samples/higgs-shop-sample-app/src/components/StartShoppingModal/StartShoppingModal.tsx
@@ -11,9 +11,11 @@ import {
 import mParticle from '@mparticle/web-sdk';
 import { HiggsLogo } from '../HiggsLogo';
 import HiggsmartLogo from '../../assets/images/higgsmart-logo.svg';
+import { useAPIKeyContext } from '../../contexts/APIKeyContext';
 
 const StartShoppingModal: React.FC = () => {
     const [open, setOpen] = useState(false);
+    const { modalMode } = useAPIKeyContext();
 
     const closeModal = () => {
         setOpen(false);
@@ -38,11 +40,13 @@ const StartShoppingModal: React.FC = () => {
         false;
 
     useEffect(() => {
-        if (!shouldIgnoreModal()) {
+        if (!shouldIgnoreModal() && modalMode === 'closed') {
             mParticle.logPageView('Landing');
             setOpen(true);
+        } else {
+            setOpen(false);
         }
-    }, []);
+    }, [modalMode, open]);
 
     return (
         <Dialog open={open} onClose={handleBackgroundClick}>

--- a/core-sdk-samples/higgs-shop-sample-app/src/components/StartShoppingModal/StartShoppingModal.tsx
+++ b/core-sdk-samples/higgs-shop-sample-app/src/components/StartShoppingModal/StartShoppingModal.tsx
@@ -12,6 +12,7 @@ import mParticle from '@mparticle/web-sdk';
 import { HiggsLogo } from '../HiggsLogo';
 import HiggsmartLogo from '../../assets/images/higgsmart-logo.svg';
 import { useAPIKeyContext } from '../../contexts/APIKeyContext';
+import { MODAL_MODES } from '../../constants';
 
 const StartShoppingModal: React.FC = () => {
     const [open, setOpen] = useState(false);
@@ -40,7 +41,7 @@ const StartShoppingModal: React.FC = () => {
         false;
 
     useEffect(() => {
-        if (!shouldIgnoreModal() && modalMode === 'closed') {
+        if (!shouldIgnoreModal() && modalMode === MODAL_MODES.CLOSED) {
             mParticle.logPageView('Landing');
             setOpen(true);
         } else {

--- a/core-sdk-samples/higgs-shop-sample-app/src/constants/index.ts
+++ b/core-sdk-samples/higgs-shop-sample-app/src/constants/index.ts
@@ -12,7 +12,7 @@ export enum MODAL_MODES {
     ENTRY = 'entry',
     UPDATE = 'update',
     CONFIRM = 'confirm',
-    ENV = 'env',
+    LOCAL_DEV = 'local_dev',
 }
 
 export type ModalModeTypes =
@@ -20,7 +20,7 @@ export type ModalModeTypes =
     | MODAL_MODES.ENTRY
     | MODAL_MODES.UPDATE
     | MODAL_MODES.CONFIRM
-    | MODAL_MODES.ENV;
+    | MODAL_MODES.LOCAL_DEV;
 
 export type OrderPhaseTypes =
     | ORDER_PHASES.IN_PROGRESS

--- a/core-sdk-samples/higgs-shop-sample-app/src/constants/index.ts
+++ b/core-sdk-samples/higgs-shop-sample-app/src/constants/index.ts
@@ -7,6 +7,21 @@ export enum ORDER_PHASES {
     COMPLETE = 'complete',
 }
 
+export enum MODAL_MODES {
+    CLOSED = 'closed',
+    ENTRY = 'entry',
+    UPDATE = 'update',
+    CONFIRM = 'confirm',
+    ENV = 'env',
+}
+
+export type ModalModeTypes =
+    | MODAL_MODES.CLOSED
+    | MODAL_MODES.ENTRY
+    | MODAL_MODES.UPDATE
+    | MODAL_MODES.CONFIRM
+    | MODAL_MODES.ENV;
+
 export type OrderPhaseTypes =
     | ORDER_PHASES.IN_PROGRESS
     | ORDER_PHASES.REVIEW
@@ -14,3 +29,5 @@ export type OrderPhaseTypes =
 
 export const APIkeyModalMessage =
     'You have started the app without an API key in the config. For information on how to add your API key, see the README.md. Once you add your API key, restart your server for changes to take effect.';
+
+export const LOCAL_STORAGE_KEY = 'mp-higgs-shop';

--- a/core-sdk-samples/higgs-shop-sample-app/src/contexts/APIKeyContext.tsx
+++ b/core-sdk-samples/higgs-shop-sample-app/src/contexts/APIKeyContext.tsx
@@ -69,7 +69,7 @@ const APIKeyContextProvider: React.FC = ({ children }) => {
 
     useEffect(() => {
         if (!apiKey && !isHosted) {
-            setModalMode(MODAL_MODES.ENV);
+            setModalMode(MODAL_MODES.LOCAL_DEV);
         } else if (!apiKey && isHosted) {
             setModalMode(MODAL_MODES.ENTRY);
         }
@@ -85,7 +85,7 @@ const APIKeyContextProvider: React.FC = ({ children }) => {
                 isOpen={modalMode === MODAL_MODES.CONFIRM}
             />
             <APIKeyEnvMessageModal
-                isOpen={modalMode === MODAL_MODES.ENV && !apiKey}
+                isOpen={modalMode === MODAL_MODES.LOCAL_DEV && !apiKey}
             />
             {children}
         </APIKeyContext.Provider>

--- a/core-sdk-samples/higgs-shop-sample-app/src/contexts/APIKeyContext.tsx
+++ b/core-sdk-samples/higgs-shop-sample-app/src/contexts/APIKeyContext.tsx
@@ -1,0 +1,69 @@
+// TS incorrectly flags function declarations as unused variables
+/* eslint-disable no-unused-vars */
+import React, {
+    createContext,
+    useContext,
+    useEffect,
+    useMemo,
+    useState,
+} from 'react';
+import {
+    APIKeyEntryModal,
+    APIKeyRemoveConfirmationModal,
+    APIKeyUpdateModal,
+} from '../components/APIKeyModal';
+
+type modalModeType = 'closed' | 'entry' | 'update' | 'confirm';
+
+interface APIKeyContextStore {
+    apiKey: string;
+    setAPIKey(apiKey: string): void;
+    setModalMode(mode: modalModeType): void;
+}
+
+const APIKeyContext = createContext({} as APIKeyContextStore);
+
+export function useAPIKeyContext() {
+    const context = useContext(APIKeyContext);
+
+    if (!context) {
+        throw new Error(
+            'useAPIKeyContext must be used within a APIKeyContextProvider',
+        );
+    }
+
+    return context;
+}
+
+const APIKeyContextProvider: React.FC = ({ children }) => {
+    // TODO: Should we provide methods to change the api key here?
+    //     const apiKey = '12346';
+    const [apiKey, setAPIKey] = useState('');
+    const [modalMode, setModalMode] = useState<modalModeType>('closed');
+
+    const value = useMemo(() => {
+        return { apiKey, setAPIKey, setModalMode };
+    }, [apiKey, setAPIKey, setModalMode]);
+
+    useEffect(() => {
+        console.log('what is modal mode?', modalMode);
+    }, [modalMode]);
+
+    useEffect(() => {
+        console.log('what is my api key?', apiKey);
+    }, [apiKey]);
+
+    return (
+        <APIKeyContext.Provider value={value}>
+            <APIKeyEntryModal onSetAPIKey={setAPIKey} />
+            <APIKeyUpdateModal
+                currentApiKey={apiKey}
+                isOpen={modalMode === 'update'}
+            />
+            <APIKeyRemoveConfirmationModal isOpen={modalMode === 'confirm'} />
+            {children}
+        </APIKeyContext.Provider>
+    );
+};
+
+export default APIKeyContextProvider;

--- a/core-sdk-samples/higgs-shop-sample-app/src/hooks/useAPIKey.ts
+++ b/core-sdk-samples/higgs-shop-sample-app/src/hooks/useAPIKey.ts
@@ -1,0 +1,31 @@
+// import { Dispatch, SetStateAction, useState } from 'react';
+import useLocalStorage from './useLocalStorage';
+// import { useState } from 'react';
+
+// type SetValue<T> = Dispatch<SetStateAction<T>>;
+
+// TODO: Workflow
+// Check if is hosted
+// .  if not hosted, read from env variables
+// ..    render env modal
+// .  if hosted, check local storage
+// ..    render hosted modal
+
+// function useApiKey(): [string, Dispatch<SetStateAction<string>>] {
+function useApiKey(): [string | undefined, boolean | undefined] {
+    const [localStorageApiKey] = useLocalStorage('mp-sample-app-api-key', '');
+    const envApiKey = process.env.REACT_APP_MPARTICLE_API_KEY;
+
+    const isHosted = process.env.REACT_APP_HOSTED?.toLowerCase() === 'true';
+
+    let apiKey = '';
+    if (isHosted) {
+        apiKey = localStorageApiKey || '';
+    } else {
+        apiKey = envApiKey || '';
+    }
+
+    return [apiKey, isHosted];
+}
+
+export default useApiKey;

--- a/core-sdk-samples/higgs-shop-sample-app/src/hooks/useAPIKey.ts
+++ b/core-sdk-samples/higgs-shop-sample-app/src/hooks/useAPIKey.ts
@@ -1,19 +1,8 @@
-// import { Dispatch, SetStateAction, useState } from 'react';
+import { LOCAL_STORAGE_KEY } from '../constants';
 import useLocalStorage from './useLocalStorage';
-// import { useState } from 'react';
 
-// type SetValue<T> = Dispatch<SetStateAction<T>>;
-
-// TODO: Workflow
-// Check if is hosted
-// .  if not hosted, read from env variables
-// ..    render env modal
-// .  if hosted, check local storage
-// ..    render hosted modal
-
-// function useApiKey(): [string, Dispatch<SetStateAction<string>>] {
 function useApiKey(): [string | undefined, boolean | undefined] {
-    const [localStorageApiKey] = useLocalStorage('mp-sample-app-api-key', '');
+    const [localStorageApiKey] = useLocalStorage(LOCAL_STORAGE_KEY, '');
     const envApiKey = process.env.REACT_APP_MPARTICLE_API_KEY;
 
     const isHosted = process.env.REACT_APP_HOSTED?.toLowerCase() === 'true';

--- a/core-sdk-samples/higgs-shop-sample-app/src/hooks/useLocalStorage.ts
+++ b/core-sdk-samples/higgs-shop-sample-app/src/hooks/useLocalStorage.ts
@@ -43,7 +43,7 @@ function useLocalStorage<T>(
                 window.localStorage.removeItem(key);
             }
         } catch (error) {
-            console.error(error);
+            console.error('Error removing APIKey', error);
         }
     };
 

--- a/core-sdk-samples/higgs-shop-sample-app/src/hooks/useLocalStorage.ts
+++ b/core-sdk-samples/higgs-shop-sample-app/src/hooks/useLocalStorage.ts
@@ -1,0 +1,53 @@
+/* eslint-disable no-console */
+import { Dispatch, SetStateAction, useState } from 'react';
+
+type SetValue<T> = Dispatch<SetStateAction<T>>;
+
+function useLocalStorage<T>(
+    key: string,
+    initialValue: T,
+): [T, SetValue<T>, () => void] {
+    const [storedValue, setStoredValue] = useState<T>(() => {
+        if (typeof window === 'undefined') {
+            return initialValue;
+        }
+
+        try {
+            const item = window.localStorage.getItem(key);
+
+            return item ? JSON.parse(item) : initialValue;
+        } catch (error) {
+            console.error(`Error reading localStorage key "${key}"`, error);
+            return initialValue;
+        }
+    });
+
+    const setValue = (value: any) => {
+        try {
+            const valueToStore =
+                value instanceof Function ? value(storedValue) : value;
+
+            setStoredValue(valueToStore);
+
+            if (typeof window !== 'undefined') {
+                window.localStorage.setItem(key, JSON.stringify(valueToStore));
+            }
+        } catch (error) {
+            console.error(`Error setting localStorage key "${key}"`, error);
+        }
+    };
+
+    const removeValue = () => {
+        try {
+            if (typeof window !== 'undefined') {
+                window.localStorage.removeItem(key);
+            }
+        } catch (error) {
+            console.error(error);
+        }
+    };
+
+    return [storedValue, setValue, removeValue];
+}
+
+export default useLocalStorage;

--- a/core-sdk-samples/higgs-shop-sample-app/src/layouts/App/index.tsx
+++ b/core-sdk-samples/higgs-shop-sample-app/src/layouts/App/index.tsx
@@ -19,17 +19,19 @@ import { MessageModal } from '../../components/MessageModal';
 import { APIkeyModalMessage } from '../../constants';
 import { APIKeyHeaderBar } from '../../components/APIKeyHeaderBar';
 // TODO: Temporarily hidden until functionality is wired in
-// import {
-// APIKeyUpdateModal,
+import // APIKeyUpdateModal,
 // APIKeyEntryModal,
 // APIKeyRemoveConfirmationModal,
-// } from '../../components/APIKeyModal';
+'../../components/APIKeyModal';
+import APIKeyContextProvider from '../../contexts/APIKeyContext';
 
 // (optional) Use the package version number to keep your appVersion up-to-date
 const { version } = require('../../../package.json');
 
 const App = () => {
     const [apiKeyModalOpen, setApiKeyModalOpen] = useState(false);
+    // const [apiKeyEntered, setAPIKeyEntered] = useState('');
+    const [apiKeyEntered] = useState('');
 
     const mParticleConfig: mParticle.MPConfiguration = {
         // (optional) `appName and appVersion are used to associate with your web app
@@ -86,71 +88,84 @@ const App = () => {
     // this should be defined in .env the
     const apiKey = process.env.REACT_APP_MPARTICLE_API_KEY;
 
+    console.warn('is hosted?', process.env.REACT_APP_HOSTED);
+
     useEffect(() => {
-        if (apiKey) {
+        console.warn('api key entered', apiKeyEntered);
+        if (apiKeyEntered) {
+            mParticle.init(apiKeyEntered, mParticleConfig);
+        } else if (apiKey) {
+            // TODO: Refactor to hide Hosted flow
             mParticle.init(apiKey, mParticleConfig);
         } else {
             setApiKeyModalOpen(true);
             console.error('Please add your mParticle API Key');
         }
-    }, []);
+    }, [apiKeyEntered]);
 
     return (
         <div className='App'>
             <ThemeProvider theme={theme}>
-                <UserDetailsProvider>
-                    <OrderDetailsProvider>
-                        <BrowserRouter>
-                            {/* Hide Shopping dialog if api key warning is visible */}
-                            {!apiKeyModalOpen && <StartShoppingModal />}
-                            <MessageModal
-                                message={APIkeyModalMessage}
-                                open={apiKeyModalOpen}
-                                buttonAction={
-                                    <>
-                                        <Button
-                                            variant='contained'
-                                            target='_blank'
-                                            href='https://github.com/mParticle/mparticle-web-sample-apps/blob/main/core-sdk-samples/higgs-shop-sample-app/README.md'
-                                        >
-                                            Go to Readme
-                                        </Button>
-                                        <Button
-                                            variant='contained'
-                                            target='_blank'
-                                            href='https://docs.mparticle.com/developers/quickstart/senddata/#1-generate-your-api-key-2'
-                                        >
-                                            Go to Docs
-                                        </Button>
-                                    </>
-                                }
-                            />
-                            <APIKeyHeaderBar />
-                            {/* 
+                <APIKeyContextProvider>
+                    <UserDetailsProvider>
+                        <OrderDetailsProvider>
+                            <BrowserRouter>
+                                {/* Hide Shopping dialog if api key warning is visible */}
+                                {!apiKeyModalOpen && <StartShoppingModal />}
+                                <MessageModal
+                                    message={APIkeyModalMessage}
+                                    open={apiKeyModalOpen}
+                                    buttonAction={
+                                        <>
+                                            <Button
+                                                variant='contained'
+                                                target='_blank'
+                                                href='https://github.com/mParticle/mparticle-web-sample-apps/blob/main/core-sdk-samples/higgs-shop-sample-app/README.md'
+                                            >
+                                                Go to Readme
+                                            </Button>
+                                            <Button
+                                                variant='contained'
+                                                target='_blank'
+                                                href='https://docs.mparticle.com/developers/quickstart/senddata/#1-generate-your-api-key-2'
+                                            >
+                                                Go to Docs
+                                            </Button>
+                                        </>
+                                    }
+                                />
+                                <APIKeyHeaderBar />
+                                {/* <APIKeyEntryModal
+                                    onSetAPIKey={setAPIKeyEntered}
+                                /> */}
+                                {/* 
                             // TODO: Temporarily hidden until functionality is wired in
                             <APIKeyRemoveConfirmationModal />
-                            <APIKeyEntryModal />
                             <APIKeyUpdateModal
                                 currentApiKey={apiKey || '12345'}
                             /> */}
-                            <NavigationMenu />
-                            <Routes>
-                                <Route path='/' element={<ShopPage />} />
-                                <Route path='shop' element={<ShopPage />} />
-                                <Route path='about' element={<AboutPage />} />
-                                <Route
-                                    path='account'
-                                    element={<AccountPage />}
-                                />
-                                <Route path='cart' element={<CartPage />} />
-                                <Route
-                                    path='/products/:id'
-                                    element={<ProductDetailPage />}
-                                />
-                            </Routes>
-                        </BrowserRouter>
-                    </OrderDetailsProvider>
-                </UserDetailsProvider>
+                                <NavigationMenu />
+                                <Routes>
+                                    <Route path='/' element={<ShopPage />} />
+                                    <Route path='shop' element={<ShopPage />} />
+                                    <Route
+                                        path='about'
+                                        element={<AboutPage />}
+                                    />
+                                    <Route
+                                        path='account'
+                                        element={<AccountPage />}
+                                    />
+                                    <Route path='cart' element={<CartPage />} />
+                                    <Route
+                                        path='/products/:id'
+                                        element={<ProductDetailPage />}
+                                    />
+                                </Routes>
+                            </BrowserRouter>
+                        </OrderDetailsProvider>
+                    </UserDetailsProvider>
+                </APIKeyContextProvider>
             </ThemeProvider>
         </div>
     );

--- a/core-sdk-samples/higgs-shop-sample-app/src/layouts/App/index.tsx
+++ b/core-sdk-samples/higgs-shop-sample-app/src/layouts/App/index.tsx
@@ -18,11 +18,6 @@ import { AccountPage } from '../../pages/AccountPage';
 import { MessageModal } from '../../components/MessageModal';
 import { APIkeyModalMessage } from '../../constants';
 import { APIKeyHeaderBar } from '../../components/APIKeyHeaderBar';
-// TODO: Temporarily hidden until functionality is wired in
-import // APIKeyUpdateModal,
-// APIKeyEntryModal,
-// APIKeyRemoveConfirmationModal,
-'../../components/APIKeyModal';
 import APIKeyContextProvider from '../../contexts/APIKeyContext';
 
 // (optional) Use the package version number to keep your appVersion up-to-date
@@ -85,7 +80,12 @@ const App = () => {
         },
     };
 
-    // this should be defined in .env the
+    // In a standard implementation, you should load your mParticle API Key via
+    // an environment variable.
+    // For example: const apiKey = process.env.REACT_APP_MPARTICLE_API_KEY;
+    // As this is a sample app, we are using a modal to allow the API Key to
+    // be modified in run time, which is not something you should do in a
+    // production application.
     const apiKey = process.env.REACT_APP_MPARTICLE_API_KEY;
 
     console.warn('is hosted?', process.env.REACT_APP_HOSTED);
@@ -135,15 +135,6 @@ const App = () => {
                                     }
                                 />
                                 <APIKeyHeaderBar />
-                                {/* <APIKeyEntryModal
-                                    onSetAPIKey={setAPIKeyEntered}
-                                /> */}
-                                {/* 
-                            // TODO: Temporarily hidden until functionality is wired in
-                            <APIKeyRemoveConfirmationModal />
-                            <APIKeyUpdateModal
-                                currentApiKey={apiKey || '12345'}
-                            /> */}
                                 <NavigationMenu />
                                 <Routes>
                                     <Route path='/' element={<ShopPage />} />

--- a/core-sdk-samples/higgs-shop-sample-app/src/layouts/App/index.tsx
+++ b/core-sdk-samples/higgs-shop-sample-app/src/layouts/App/index.tsx
@@ -1,9 +1,8 @@
 /* eslint-disable no-console */
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import mParticle from '@mparticle/web-sdk';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import { ThemeProvider } from '@mui/material/styles';
-// import { Button } from '@mui/material';
 import { NavigationMenu } from '../../components/NavigationMenu';
 import { ShopPage } from '../../pages/ShopPage';
 import { AboutPage } from '../../pages/AboutPage';
@@ -17,15 +16,12 @@ import { AccountPage } from '../../pages/AccountPage';
 import { APIKeyHeaderBar } from '../../components/APIKeyHeaderBar';
 import APIKeyContextProvider from '../../contexts/APIKeyContext';
 import useApiKey from '../../hooks/useAPIKey';
+import { StartShoppingModal } from '../../components/StartShoppingModal';
 
 // (optional) Use the package version number to keep your appVersion up-to-date
 const { version } = require('../../../package.json');
 
 const App = () => {
-    const [apiKeyEntered] = useState('');
-    // TODO: Consolidate DasAPIKey with apiKey
-    const [dasApiKey] = useApiKey();
-
     const mParticleConfig: mParticle.MPConfiguration = {
         // (optional) `appName and appVersion are used to associate with your web app
         // and are included in all event uploads
@@ -78,29 +74,28 @@ const App = () => {
         },
     };
 
-    // In a standard implementation, you should load your mParticle API Key via
+    // In a true production implementation, you should load your mParticle API Key via
     // an environment variable.
-    // For example: const apiKey = process.env.REACT_APP_MPARTICLE_API_KEY;
-    // As this is a sample app, we are using a modal to allow the API Key to
-    // be modified in run time, which is not something you should do in a
-    // production application.
-    const apiKey = process.env.REACT_APP_MPARTICLE_API_KEY;
+    // For example:
+    //
+    // const apiKey = process.env.REACT_APP_MPARTICLE_API_KEY;
+    //
+    // As this is an interactive sample app, we are using a custom hook to
+    // allow an API Key to be modified in run time.
+
+    const [apiKey] = useApiKey();
+
+    // It is however recommended that once the API Key is instantiated,
+    // that you use a `useEffect` statement like the example below so that
+    // mParticle initializes immediately once your App component is mounted.
 
     useEffect(() => {
-        console.warn('api key entered', apiKeyEntered);
-        if (apiKeyEntered) {
-            mParticle.init(apiKeyEntered, mParticleConfig);
-        } else if (apiKey) {
-            // TODO: Refactor to hide Hosted flow
+        if (apiKey) {
             mParticle.init(apiKey, mParticleConfig);
         } else {
             console.error('Please add your mParticle API Key');
         }
-    }, [apiKeyEntered]);
-
-    useEffect(() => {
-        console.log('fetching api key from hooks', dasApiKey);
-    }, [dasApiKey]);
+    }, [apiKey]);
 
     return (
         <div className='App'>
@@ -109,9 +104,7 @@ const App = () => {
                     <UserDetailsProvider>
                         <OrderDetailsProvider>
                             <BrowserRouter>
-                                {/* TODO: Restore Start Shopping Modal */}
-                                {/* Hide Shopping dialog if api key warning is visible */}
-                                {/* {!apiKeyModalOpen && <StartShoppingModal />} */}
+                                <StartShoppingModal />
 
                                 <APIKeyHeaderBar />
                                 <NavigationMenu />

--- a/core-sdk-samples/higgs-shop-sample-app/src/layouts/App/index.tsx
+++ b/core-sdk-samples/higgs-shop-sample-app/src/layouts/App/index.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react';
 import mParticle from '@mparticle/web-sdk';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import { ThemeProvider } from '@mui/material/styles';
-import { Button } from '@mui/material';
+// import { Button } from '@mui/material';
 import { NavigationMenu } from '../../components/NavigationMenu';
 import { ShopPage } from '../../pages/ShopPage';
 import { AboutPage } from '../../pages/AboutPage';
@@ -11,22 +11,20 @@ import './index.css';
 import theme from '../../contexts/theme';
 import { ProductDetailPage } from '../../pages/ProductDetailPage';
 import { CartPage } from '../../pages/CartPage';
-import { StartShoppingModal } from '../../components/StartShoppingModal';
 import OrderDetailsProvider from '../../contexts/OrderDetails';
 import UserDetailsProvider from '../../contexts/UserDetails';
 import { AccountPage } from '../../pages/AccountPage';
-import { MessageModal } from '../../components/MessageModal';
-import { APIkeyModalMessage } from '../../constants';
 import { APIKeyHeaderBar } from '../../components/APIKeyHeaderBar';
 import APIKeyContextProvider from '../../contexts/APIKeyContext';
+import useApiKey from '../../hooks/useAPIKey';
 
 // (optional) Use the package version number to keep your appVersion up-to-date
 const { version } = require('../../../package.json');
 
 const App = () => {
-    const [apiKeyModalOpen, setApiKeyModalOpen] = useState(false);
-    // const [apiKeyEntered, setAPIKeyEntered] = useState('');
     const [apiKeyEntered] = useState('');
+    // TODO: Consolidate DasAPIKey with apiKey
+    const [dasApiKey] = useApiKey();
 
     const mParticleConfig: mParticle.MPConfiguration = {
         // (optional) `appName and appVersion are used to associate with your web app
@@ -88,8 +86,6 @@ const App = () => {
     // production application.
     const apiKey = process.env.REACT_APP_MPARTICLE_API_KEY;
 
-    console.warn('is hosted?', process.env.REACT_APP_HOSTED);
-
     useEffect(() => {
         console.warn('api key entered', apiKeyEntered);
         if (apiKeyEntered) {
@@ -98,10 +94,13 @@ const App = () => {
             // TODO: Refactor to hide Hosted flow
             mParticle.init(apiKey, mParticleConfig);
         } else {
-            setApiKeyModalOpen(true);
             console.error('Please add your mParticle API Key');
         }
     }, [apiKeyEntered]);
+
+    useEffect(() => {
+        console.log('fetching api key from hooks', dasApiKey);
+    }, [dasApiKey]);
 
     return (
         <div className='App'>
@@ -110,30 +109,10 @@ const App = () => {
                     <UserDetailsProvider>
                         <OrderDetailsProvider>
                             <BrowserRouter>
+                                {/* TODO: Restore Start Shopping Modal */}
                                 {/* Hide Shopping dialog if api key warning is visible */}
-                                {!apiKeyModalOpen && <StartShoppingModal />}
-                                <MessageModal
-                                    message={APIkeyModalMessage}
-                                    open={apiKeyModalOpen}
-                                    buttonAction={
-                                        <>
-                                            <Button
-                                                variant='contained'
-                                                target='_blank'
-                                                href='https://github.com/mParticle/mparticle-web-sample-apps/blob/main/core-sdk-samples/higgs-shop-sample-app/README.md'
-                                            >
-                                                Go to Readme
-                                            </Button>
-                                            <Button
-                                                variant='contained'
-                                                target='_blank'
-                                                href='https://docs.mparticle.com/developers/quickstart/senddata/#1-generate-your-api-key-2'
-                                            >
-                                                Go to Docs
-                                            </Button>
-                                        </>
-                                    }
-                                />
+                                {/* {!apiKeyModalOpen && <StartShoppingModal />} */}
+
                                 <APIKeyHeaderBar />
                                 <NavigationMenu />
                                 <Routes>

--- a/core-sdk-samples/higgs-shop-sample-app/src/test-utils/helpers.tsx
+++ b/core-sdk-samples/higgs-shop-sample-app/src/test-utils/helpers.tsx
@@ -3,6 +3,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React, { ReactElement } from 'react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import APIKeyContextProvider from '../contexts/APIKeyContext';
 import OrderDetailsProvider from '../contexts/OrderDetails';
 
 const updateQuantity = async (quantity: number) => {
@@ -130,6 +131,10 @@ export const renderWithRouter = (
             </MemoryRouter>
         </OrderDetailsProvider>,
     );
+};
+
+export const renderWithAPIKeyContext = (element: ReactElement) => {
+    render(<APIKeyContextProvider>{element}</APIKeyContextProvider>);
 };
 
 export const mockCreateProduct = () => {


### PR DESCRIPTION
## Summary
- Set up Web Sample App to allow a Web API Key to be copy/pasted into the sample app via a modal when hosted on a third party service (i.e. Github Pages). This assumes that a `REACT_APP_HOSTED` env variable is set (which will be in the settings of the repo) and will control the rendering of the Modal, as well as desktop and mobile UI components that will toggle the modals.
- In this workflow, there will be three "states" for the API Key workflow
  - Enter Key Mode - Initial state that will add the key to the sample app
  - Update Key Mode - Allows the key to be changed or modified during runtime
  - Remove Key Mode - Removes the key from the app and resets app back to the initial state. Has a confirmation step
- All UI Modes will access the browser's localStorage and persist key storage or remove the key in the case of the Removal mode
- Should a user decide to clone the repo and run the code locally, the existing .env api key workflow will still be enabled, allowing a user building locally to bypass the UI workflow.

## Testing Plan
- Run automated tests
- Test code locally

## Master Issue
- Closes https://go.mparticle.com/work/SQDSDKS-4102
