### PR TITLE
Allow API Key via query param

### DIFF
--- a/core-sdk-samples/higgs-shop-sample-app/src/components/APIKeyModal/APIKeyEntryModal.test.tsx
+++ b/core-sdk-samples/higgs-shop-sample-app/src/components/APIKeyModal/APIKeyEntryModal.test.tsx
@@ -49,6 +49,18 @@ describe('API Key Entry Modal', () => {
         expect(saveAndGoButton).toBeDisabled();
     });
 
+    test('should allow an API Key as a parameter', () => {
+        renderWithAPIKeyContext(
+            <APIKeyEntryModal isOpen initialKey='XXXXXX' />,
+        );
+
+        const keyTextField = screen.getByRole('textbox', {
+            name: /key/i,
+        });
+
+        expect(keyTextField).toHaveValue('XXXXXX');
+    });
+
     test('should enable Save & Go button if API Key is Entered', async () => {
         renderWithAPIKeyContext(<APIKeyEntryModal isOpen />);
 

--- a/core-sdk-samples/higgs-shop-sample-app/src/components/APIKeyModal/APIKeyEntryModal.tsx
+++ b/core-sdk-samples/higgs-shop-sample-app/src/components/APIKeyModal/APIKeyEntryModal.tsx
@@ -23,7 +23,7 @@ interface APIKeyEntryModalProps {
 
 const APIKeyEntryModal: React.FC<APIKeyEntryModalProps> = ({ isOpen }) => {
     const [currentAPIKey, setCurrentAPIKey] = useState('');
-    const [open, setOpen] = useState(true);
+    const [open, setOpen] = useState(false);
 
     const { setModalMode, apiKey, setAPIKey } = useAPIKeyContext();
 

--- a/core-sdk-samples/higgs-shop-sample-app/src/components/APIKeyModal/APIKeyEntryModal.tsx
+++ b/core-sdk-samples/higgs-shop-sample-app/src/components/APIKeyModal/APIKeyEntryModal.tsx
@@ -23,7 +23,7 @@ interface APIKeyEntryModalProps {
 
 const APIKeyEntryModal: React.FC<APIKeyEntryModalProps> = ({ isOpen }) => {
     const [currentAPIKey, setCurrentAPIKey] = useState('');
-    const [open, setOpen] = useState(false);
+    const [open, setOpen] = useState(true);
 
     const { setModalMode, apiKey, setAPIKey } = useAPIKeyContext();
 

--- a/core-sdk-samples/higgs-shop-sample-app/src/components/APIKeyModal/APIKeyEntryModal.tsx
+++ b/core-sdk-samples/higgs-shop-sample-app/src/components/APIKeyModal/APIKeyEntryModal.tsx
@@ -19,13 +19,17 @@ import { MODAL_MODES } from '../../constants';
 
 interface APIKeyEntryModalProps {
     isOpen?: boolean;
+    initialKey?: string;
 }
 
-const APIKeyEntryModal: React.FC<APIKeyEntryModalProps> = ({ isOpen }) => {
-    const [currentAPIKey, setCurrentAPIKey] = useState('');
+const APIKeyEntryModal: React.FC<APIKeyEntryModalProps> = ({
+    isOpen,
+    initialKey,
+}) => {
+    const [currentAPIKey, setCurrentAPIKey] = useState(initialKey || '');
     const [open, setOpen] = useState(false);
 
-    const { setModalMode, apiKey, setAPIKey } = useAPIKeyContext();
+    const { setModalMode, setAPIKey } = useAPIKeyContext();
 
     const closeModal = () => {
         setModalMode(MODAL_MODES.ENTRY);
@@ -110,6 +114,7 @@ const APIKeyEntryModal: React.FC<APIKeyEntryModalProps> = ({ isOpen }) => {
                             <TextField
                                 id='apiKey'
                                 label='Key'
+                                value={currentAPIKey}
                                 placeholder='Paste your Key here'
                                 onChange={(e) =>
                                     setCurrentAPIKey(e.target.value)
@@ -137,6 +142,7 @@ const APIKeyEntryModal: React.FC<APIKeyEntryModalProps> = ({ isOpen }) => {
 
 APIKeyEntryModal.defaultProps = {
     isOpen: false,
+    initialKey: undefined,
 };
 
 export default APIKeyEntryModal;

--- a/core-sdk-samples/higgs-shop-sample-app/src/components/APIKeyModal/APIKeyUpdateModal.tsx
+++ b/core-sdk-samples/higgs-shop-sample-app/src/components/APIKeyModal/APIKeyUpdateModal.tsx
@@ -66,7 +66,6 @@ const APIKeyUpdateModal: React.FC<APIKeyUpdateModalProps> = ({ isOpen }) => {
         }
     };
 
-    // TODO: Can we remove this?
     useEffect(() => {
         // Reset the api key in the ui component back to whatever is currently in
         // the application state

--- a/core-sdk-samples/higgs-shop-sample-app/src/components/APIKeyModal/APIKeyUpdateModal.tsx
+++ b/core-sdk-samples/higgs-shop-sample-app/src/components/APIKeyModal/APIKeyUpdateModal.tsx
@@ -66,6 +66,7 @@ const APIKeyUpdateModal: React.FC<APIKeyUpdateModalProps> = ({ isOpen }) => {
         }
     };
 
+    // TODO: Can we remove this?
     useEffect(() => {
         // Reset the api key in the ui component back to whatever is currently in
         // the application state
@@ -73,6 +74,7 @@ const APIKeyUpdateModal: React.FC<APIKeyUpdateModalProps> = ({ isOpen }) => {
         setCanUpdateAPIKey(false);
     }, [open]);
 
+    // TODO: Can we remove this?
     useEffect(() => {
         // Listens for the `isOpen` state to make sure
         // component stays closed when it isn't needed

--- a/core-sdk-samples/higgs-shop-sample-app/src/components/APIKeyModal/APIKeyUpdateModal.tsx
+++ b/core-sdk-samples/higgs-shop-sample-app/src/components/APIKeyModal/APIKeyUpdateModal.tsx
@@ -73,7 +73,6 @@ const APIKeyUpdateModal: React.FC<APIKeyUpdateModalProps> = ({ isOpen }) => {
         setCanUpdateAPIKey(false);
     }, [open]);
 
-    // TODO: Can we remove this?
     useEffect(() => {
         // Listens for the `isOpen` state to make sure
         // component stays closed when it isn't needed

--- a/core-sdk-samples/higgs-shop-sample-app/src/constants/index.ts
+++ b/core-sdk-samples/higgs-shop-sample-app/src/constants/index.ts
@@ -31,3 +31,5 @@ export const APIkeyModalMessage =
     'You have started the app without an API key in the config. For information on how to add your API key, see the README.md. Once you add your API key, restart your server for changes to take effect.';
 
 export const LOCAL_STORAGE_KEY = 'mp-higgs-shop';
+
+export const API_KEY_QUERY_PARAM = 'key';

--- a/core-sdk-samples/higgs-shop-sample-app/src/contexts/APIKeyContext.tsx
+++ b/core-sdk-samples/higgs-shop-sample-app/src/contexts/APIKeyContext.tsx
@@ -39,6 +39,8 @@ export function useAPIKeyContext() {
     return context;
 }
 
+// TODO: Reload app every time API Key changes or is updated
+
 const APIKeyContextProvider: React.FC = ({ children }) => {
     const [apiKey, isHosted] = useApiKey();
     const [localStorageApiKey, setLocalStorageApiKey, removeLocalStorageKey] =

--- a/core-sdk-samples/higgs-shop-sample-app/src/contexts/APIKeyContext.tsx
+++ b/core-sdk-samples/higgs-shop-sample-app/src/contexts/APIKeyContext.tsx
@@ -39,9 +39,6 @@ export function useAPIKeyContext() {
     return context;
 }
 
-// TODO: Reload app every time API Key changes or is updated
-// TODO: Move message modal from index to here
-
 const APIKeyContextProvider: React.FC = ({ children }) => {
     const [apiKey, isHosted] = useApiKey();
     const [localStorageApiKey, setLocalStorageApiKey, removeLocalStorageKey] =

--- a/core-sdk-samples/higgs-shop-sample-app/src/contexts/APIKeyContext.tsx
+++ b/core-sdk-samples/higgs-shop-sample-app/src/contexts/APIKeyContext.tsx
@@ -7,13 +7,19 @@ import React, {
     useMemo,
     useState,
 } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import {
     APIKeyEntryModal,
     APIKeyRemoveConfirmationModal,
     APIKeyUpdateModal,
     APIKeyEnvMessageModal,
 } from '../components/APIKeyModal';
-import { LOCAL_STORAGE_KEY, ModalModeTypes, MODAL_MODES } from '../constants';
+import {
+    API_KEY_QUERY_PARAM,
+    LOCAL_STORAGE_KEY,
+    ModalModeTypes,
+    MODAL_MODES,
+} from '../constants';
 import useApiKey from '../hooks/useAPIKey';
 import useLocalStorage from '../hooks/useLocalStorage';
 
@@ -43,9 +49,12 @@ const APIKeyContextProvider: React.FC = ({ children }) => {
     const [apiKey, isHosted] = useApiKey();
     const [localStorageApiKey, setLocalStorageApiKey, removeLocalStorageKey] =
         useLocalStorage(LOCAL_STORAGE_KEY, '');
+    const [searchParams, setSearchParams] = useSearchParams();
     const [modalMode, setModalMode] = useState<ModalModeTypes>(
         MODAL_MODES.CLOSED,
     );
+
+    const queryParamKey = searchParams.get(API_KEY_QUERY_PARAM);
 
     const value = useMemo(() => {
         const setAPIKey = (key: string) => {
@@ -79,6 +88,7 @@ const APIKeyContextProvider: React.FC = ({ children }) => {
         <APIKeyContext.Provider value={value}>
             <APIKeyEntryModal
                 isOpen={modalMode === MODAL_MODES.ENTRY && !apiKey}
+                initialKey={queryParamKey || undefined}
             />
             <APIKeyUpdateModal isOpen={modalMode === MODAL_MODES.UPDATE} />
             <APIKeyRemoveConfirmationModal

--- a/core-sdk-samples/higgs-shop-sample-app/src/contexts/APIKeyContext.tsx
+++ b/core-sdk-samples/higgs-shop-sample-app/src/contexts/APIKeyContext.tsx
@@ -40,6 +40,7 @@ export function useAPIKeyContext() {
 }
 
 // TODO: Reload app every time API Key changes or is updated
+// TODO: Move message modal from index to here
 
 const APIKeyContextProvider: React.FC = ({ children }) => {
     const [apiKey, isHosted] = useApiKey();

--- a/core-sdk-samples/higgs-shop-sample-app/src/layouts/App/index.tsx
+++ b/core-sdk-samples/higgs-shop-sample-app/src/layouts/App/index.tsx
@@ -100,10 +100,10 @@ const App = () => {
     return (
         <div className='App'>
             <ThemeProvider theme={theme}>
-                <APIKeyContextProvider>
-                    <UserDetailsProvider>
-                        <OrderDetailsProvider>
-                            <BrowserRouter>
+                <UserDetailsProvider>
+                    <OrderDetailsProvider>
+                        <BrowserRouter>
+                            <APIKeyContextProvider>
                                 <StartShoppingModal />
 
                                 <APIKeyHeaderBar />
@@ -125,10 +125,10 @@ const App = () => {
                                         element={<ProductDetailPage />}
                                     />
                                 </Routes>
-                            </BrowserRouter>
-                        </OrderDetailsProvider>
-                    </UserDetailsProvider>
-                </APIKeyContextProvider>
+                            </APIKeyContextProvider>
+                        </BrowserRouter>
+                    </OrderDetailsProvider>
+                </UserDetailsProvider>
             </ThemeProvider>
         </div>
     );

--- a/core-sdk-samples/higgs-shop-sample-app/src/test-utils/helpers.tsx
+++ b/core-sdk-samples/higgs-shop-sample-app/src/test-utils/helpers.tsx
@@ -134,7 +134,10 @@ export const renderWithRouter = (
 };
 
 export const renderWithAPIKeyContext = (element: ReactElement) => {
-    render(<APIKeyContextProvider>{element}</APIKeyContextProvider>);
+    renderWithRouter(<APIKeyContextProvider>{element}</APIKeyContextProvider>, {
+        path: '/',
+        pathSignature: '/',
+    });
 };
 
 export const mockCreateProduct = () => {


### PR DESCRIPTION
## Summary
- As a means to easier integrate with our onboarding flow, we should allow an api key to be passed in via query param
- For example, https://sampleapp.mparticle.com/higgs-shop/?key=XXXXXXXX should show the entry modal with the API Key automatically entered

## Testing Plan
- Manually test

## Master Issue
- Closes https://go.mparticle.com/work/SQDSDKS-4213
