### PR TITLE
fix: Modify routing and public images for hosting

### DIFF
--- a/core-sdk-samples/higgs-shop-sample-app/package.json
+++ b/core-sdk-samples/higgs-shop-sample-app/package.json
@@ -26,7 +26,9 @@
         "web-vitals": "^1.0.1"
     },
     "scripts": {
-        "predeploy": "BUILD_PATH=./build.tmp npm run build && mkdir -p build/higgs-shop && mv build.tmp/* build/higgs-shop && rm -rf build.tmp",
+        "predeploy": "npm run build:clean && BUILD_PATH=./build/higgs-shop npm run build",
+        "build:local-serve": "npm run build:clean && BUILD_PATH=./build/mparticle-web-sample-apps/higgs-shop npm run build",
+        "build:clean": "rm -rf build",
         "deploy": "gh-pages -d build",
         "start": "react-scripts start",
         "build": "react-scripts build",

--- a/core-sdk-samples/higgs-shop-sample-app/src/features/OrderDetails/OrderDetailsCard.tsx
+++ b/core-sdk-samples/higgs-shop-sample-app/src/features/OrderDetails/OrderDetailsCard.tsx
@@ -45,7 +45,7 @@ const OrderDetailsCard: React.FC<OrderDetailsCardProps> = ({
             <CardMedia
                 sx={{ width: { xs: 100, sm: 209 } }}
                 component='img'
-                image={imageUrl}
+                image={process.env.PUBLIC_URL + imageUrl}
                 alt={altText}
             />
             <CardContent

--- a/core-sdk-samples/higgs-shop-sample-app/src/features/ProductDetails/ProductCard.tsx
+++ b/core-sdk-samples/higgs-shop-sample-app/src/features/ProductDetails/ProductCard.tsx
@@ -37,7 +37,7 @@ const ProductCard: React.FC<ProductCardProps> = ({
                 <CardMedia
                     component='img'
                     height='361'
-                    image={imageUrl}
+                    image={process.env.PUBLIC_URL + imageUrl}
                     alt={altText}
                 />
                 <CardContent

--- a/core-sdk-samples/higgs-shop-sample-app/src/layouts/App/index.tsx
+++ b/core-sdk-samples/higgs-shop-sample-app/src/layouts/App/index.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 import { useEffect } from 'react';
 import mParticle from '@mparticle/web-sdk';
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { HashRouter, Routes, Route } from 'react-router-dom';
 import { ThemeProvider } from '@mui/material/styles';
 import { NavigationMenu } from '../../components/NavigationMenu';
 import { ShopPage } from '../../pages/ShopPage';
@@ -102,7 +102,7 @@ const App = () => {
             <ThemeProvider theme={theme}>
                 <UserDetailsProvider>
                     <OrderDetailsProvider>
-                        <BrowserRouter>
+                        <HashRouter>
                             <APIKeyContextProvider>
                                 <StartShoppingModal />
 
@@ -126,7 +126,7 @@ const App = () => {
                                     />
                                 </Routes>
                             </APIKeyContextProvider>
-                        </BrowserRouter>
+                        </HashRouter>
                     </OrderDetailsProvider>
                 </UserDetailsProvider>
             </ThemeProvider>

--- a/core-sdk-samples/higgs-shop-sample-app/src/pages/ProductDetailPage/ProductDetailPage.tsx
+++ b/core-sdk-samples/higgs-shop-sample-app/src/pages/ProductDetailPage/ProductDetailPage.tsx
@@ -187,7 +187,7 @@ const ProductDetailPage: React.FC = () => {
                                 height: 'auto',
                             }}
                             alt={product.altText}
-                            src={product.imageUrl}
+                            src={process.env.PUBLIC_URL + product.imageUrl}
                         />
                     </Grid>
                     <Grid item xs={12} sm={6}>


### PR DESCRIPTION
## Summary
- When hosted, client side rendering and routing is displaying broken images and 404s when reloading sub pages
- We should be using HashRouter and prefixing public images with the public url env variable

## Testing Plan
- Test by building and serving pages locally
  - manually run `npm run build:local-serve`
  - run http-server from root of `/build`
  - load url into browser and test
- Test deploy to github pages

## Master Issue
- Closes https://go.mparticle.com/work/SQDSDKS-4223
