### PR TITLE
ci: Add Chore Prefix to dependabot commits

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,5 @@ updates:
       target-branch: 'chore/dependabot'
       labels: ['dependabot']
       open-pull-requests-limit: 10
+      commit-message:
+        prefix: "chore"


### PR DESCRIPTION
## Summary
- Add Chore Prefix to depependabot commits

## Master Issue
- Closes https://go.mparticle.com/work/SQDSDKS-4409
