### PR TITLE
ci: Remove Node 14 from PR workflow matrix

### DIFF
--- a/.github/workflows/higgs-shop-sample-app-pull-request.yml
+++ b/.github/workflows/higgs-shop-sample-app-pull-request.yml
@@ -21,7 +21,7 @@ jobs:
         strategy:
             matrix:
                 os: [windows-latest, ubuntu-latest, macos-latest]
-                node-version: [14.x, 16.x, 17.x]
+                node-version: [16.x, 17.x]
         steps:
             - name: Checkout
               uses: actions/checkout@v2


### PR DESCRIPTION
## Instructions
1. PR target branch should be against development
2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/stable/.github/workflows/pr-title-check.yml
3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/stable/.github/workflows/pr-branch-check-name.yml

## Summary
Node 14 is EOL end of April 2023.  It is causing issues with some of our [workflows in the higgs sample app](https://github.com/mParticle/mparticle-web-sample-apps/actions/runs/4388460125/jobs/7684980424).  This PR removes this.

## Testing Plan
NA

## Master Issue
- Closes https://go.mparticle.com/work/SQDSDKS-5199